### PR TITLE
Refactor

### DIFF
--- a/Trivo.Aplicacion/Interfaces/Base/IValidacion.cs
+++ b/Trivo.Aplicacion/Interfaces/Base/IValidacion.cs
@@ -1,0 +1,8 @@
+using System.Linq.Expressions;
+
+namespace Trivo.Aplicacion.Interfaces.Base;
+
+public interface IValidacion<TEntidad> where TEntidad : class
+{
+    Task<bool> Validar (Expression<Func<TEntidad, bool>> entidadExpresion, CancellationToken cancellationToken);
+}

--- a/Trivo.Aplicacion/Interfaces/Repositorio/IRepositorioCategoriaInteres.cs
+++ b/Trivo.Aplicacion/Interfaces/Repositorio/IRepositorioCategoriaInteres.cs
@@ -1,3 +1,4 @@
+using Trivo.Aplicacion.Interfaces.Base;
 using Trivo.Aplicacion.Paginacion;
 using Trivo.Dominio.Modelos;
 
@@ -6,7 +7,7 @@ namespace Trivo.Aplicacion.Interfaces.Repositorio;
 /// <summary>
 /// Define las operaciones para gestionar categorías de interés dentro del sistema.
 /// </summary>
-public interface IRepositorioCategoriaInteres
+public interface IRepositorioCategoriaInteres : IValidacion<CategoriaInteres>
 {
     /// <summary>
     /// Crea una colección de categorías de interés en la base de datos.
@@ -40,4 +41,15 @@ public interface IRepositorioCategoriaInteres
     /// <param name="cancellationToken">Token de cancelación para la operación asincrónica.</param>
     /// <returns>Una tarea que representa la operación asincrónica.</returns>
     Task ActualizarCategoriaInteresAsync(CategoriaInteres categoriaInteres, CancellationToken cancellationToken);
+    
+    /// <summary>
+    /// Verifica si ya existe un registro con el nombre especificado.
+    /// </summary>
+    /// <param name="nombre">El nombre a verificar en la base de datos.</param>
+    /// <param name="cancellationToken">Token para cancelar la operación si es necesario.</param>
+    /// <returns>
+    /// <c>true</c> si existe un registro con ese nombre; de lo contrario, <c>false</c>.
+    /// </returns>
+    Task<bool> NombreExisteAsync(string nombre, CancellationToken cancellationToken);
+
 }

--- a/Trivo.Aplicacion/Interfaces/Repositorio/IRepositorioHabilidad.cs
+++ b/Trivo.Aplicacion/Interfaces/Repositorio/IRepositorioHabilidad.cs
@@ -1,9 +1,10 @@
+using Trivo.Aplicacion.Interfaces.Base;
 using Trivo.Aplicacion.Paginacion;
 using Trivo.Dominio.Modelos;
 
 namespace Trivo.Aplicacion.Interfaces.Repositorio;
 
-public interface IRepositorioHabilidad
+public interface IRepositorioHabilidad : IValidacion<Habilidad>
 {
     /// <summary>
     /// Crea una colección de habilidades en la base de datos.
@@ -46,4 +47,14 @@ public interface IRepositorioHabilidad
     /// <param name="cancellationToken">Token para cancelar la operación asincrónica.</param>
     /// <returns>Una tarea que retorna la colección de usuarios que poseen alguna de las habilidades indicadas.</returns>
     Task<IEnumerable<Usuario>> ObtenerUsuariosPorHabilidadesAsync(IEnumerable<Guid> habilidadId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Verifica si ya existe un interés registrado con el nombre especificado, sin importar la categoría.
+    /// </summary>
+    /// <param name="nombre">El nombre del interés a verificar.</param>
+    /// <param name="cancellationToken">Token que permite cancelar la operación de forma anticipada.</param>
+    /// <returns>
+    /// Un valor booleano que indica si existe (<c>true</c>) o no (<c>false</c>) un interés con el nombre dado.
+    /// </returns>
+    Task<bool> NombreExisteAsync(string nombre, CancellationToken cancellationToken);
 }

--- a/Trivo.Aplicacion/Interfaces/Repositorio/IRepositorioInteres.cs
+++ b/Trivo.Aplicacion/Interfaces/Repositorio/IRepositorioInteres.cs
@@ -1,3 +1,4 @@
+using Trivo.Aplicacion.Interfaces.Base;
 using Trivo.Aplicacion.Paginacion;
 using Trivo.Dominio.Modelos;
 
@@ -6,7 +7,7 @@ namespace Trivo.Aplicacion.Interfaces.Repositorio;
 /// <summary>
 /// Define las operaciones para gestionar intereses dentro del sistema.
 /// </summary>
-public interface IRepositorioInteres
+public interface IRepositorioInteres : IValidacion<Interes>
 {
     /// <summary>
     /// Crea una lista de intereses en la base de datos.
@@ -90,4 +91,25 @@ public interface IRepositorioInteres
         int numeroPagina,
         int tamanoPagina,
         CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Verifica si ya existe un interés con el nombre especificado, sin importar la categoría.
+    /// </summary>
+    /// <param name="nombre">Nombre del interés a validar.</param>
+    /// <param name="cancellationToken">Token para cancelar la operación.</param>
+    /// <returns>
+    /// <c>true</c> si ya existe un interés con ese nombre; de lo contrario, <c>false</c>.
+    /// </returns>
+    Task<bool> NombreExisteAsync(string nombre, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Verifica si ya existe un interés con el nombre especificado dentro de una categoría específica.
+    /// </summary>
+    /// <param name="nombre">Nombre del interés a validar.</param>
+    /// <param name="categoriaId">ID de la categoría donde se validará la existencia del interés.</param>
+    /// <param name="cancellationToken">Token para cancelar la operación.</param>
+    /// <returns>
+    /// <c>true</c> si ya existe un interés con ese nombre en la categoría especificada; de lo contrario, <c>false</c>.
+    /// </returns>
+    Task<bool> NombreCategoriaExisteAsync(string nombre, Guid categoriaId, CancellationToken cancellationToken);
 }

--- a/Trivo.Aplicacion/Modulos/CategoriaIntereses/Commands/CrearCategoriaInteresValidacion.cs
+++ b/Trivo.Aplicacion/Modulos/CategoriaIntereses/Commands/CrearCategoriaInteresValidacion.cs
@@ -1,0 +1,18 @@
+using FluentValidation;
+using Trivo.Aplicacion.Interfaces.Repositorio;
+
+namespace Trivo.Aplicacion.Modulos.CategoriaIntereses.Commands;
+
+public class CrearCategoriaInteresValidacion : AbstractValidator<CrearCategoriaInteresCommand>
+{
+    public CrearCategoriaInteresValidacion(IRepositorioCategoriaInteres repositorio)
+    {
+
+        RuleFor(x => x.Nombre)
+            .NotEmpty()
+            .WithMessage("El nombre no puede ser nulo")
+            .MustAsync(async (nombre, ct) => !await repositorio.NombreExisteAsync(nombre, ct))
+            .WithMessage("Este nombre ya está registrado.");
+
+    }    
+}

--- a/Trivo.Aplicacion/Modulos/Habilidades/Commands/Crear/CrearHabilidadValidacion.cs
+++ b/Trivo.Aplicacion/Modulos/Habilidades/Commands/Crear/CrearHabilidadValidacion.cs
@@ -1,0 +1,24 @@
+using FluentValidation;
+using Trivo.Aplicacion.Interfaces.Repositorio;
+
+namespace Trivo.Aplicacion.Modulos.Habilidades.Commands.Crear;
+
+public class CrearHabilidadValidacion : AbstractValidator<CrearHabilidadCommand>
+{
+    public CrearHabilidadValidacion(IRepositorioHabilidad repositorioHabilidad)
+    {
+        RuleFor(x => x.Nombre)
+            .NotEmpty()
+            .WithMessage("El nombre no puede ser nulo")
+            .MustAsync(async (nombre, ct) => !await repositorioHabilidad.NombreExisteAsync(nombre, ct))
+            .WithMessage("Este nombre ya está registrado.");
+        
+        RuleFor(x => x.UsearioId)
+            .NotEmpty()
+            .WithMessage("El id del usuario no puede ser nulo");
+
+        RuleFor(x => x.Nivel)
+            .NotEmpty()
+            .WithMessage("El nivel no puede ser nulo");
+    }
+}

--- a/Trivo.Aplicacion/Modulos/Intereses/Commands/Crear/CrearInteresValidacion.cs
+++ b/Trivo.Aplicacion/Modulos/Intereses/Commands/Crear/CrearInteresValidacion.cs
@@ -1,0 +1,31 @@
+using FluentValidation;
+using Trivo.Aplicacion.Interfaces.Repositorio;
+
+namespace Trivo.Aplicacion.Modulos.Intereses.Commands.Crear;
+
+public class CrearInteresValidacion : AbstractValidator<CrearInteresCommand>
+{
+    public CrearInteresValidacion(IRepositorioInteres repositorioInteres)
+    {
+        RuleFor(x => x.Nombre)
+            .NotEmpty()
+            .WithMessage("El nombre no puede ser nulo")
+            .MustAsync(async (nombre, ct) => !await repositorioInteres.NombreExisteAsync(nombre, ct))
+            .WithMessage("Este nombre ya está registrado");
+        
+        RuleFor(x => x.CategoriaId)
+            .NotNull()
+            .WithMessage("Debe especificar una categoría válida");
+
+        RuleFor(x => x.CreadoPor)
+            .NotNull()
+            .WithMessage("Debe especificar el usuario que crea el interés");
+        
+        // Validación compuesta: mismo nombre en la misma categoría no puede existir
+        RuleFor(x => x)
+            .MustAsync(async (command, ct) =>
+                !await repositorioInteres.NombreCategoriaExisteAsync(command.Nombre, command.CategoriaId ?? Guid.Empty, ct))
+            .WithMessage("Este interés ya existe en la categoría especificada");
+        
+    }
+}

--- a/Trivo.Aplicacion/Utilidades/EmailTemas.cs
+++ b/Trivo.Aplicacion/Utilidades/EmailTemas.cs
@@ -4,252 +4,631 @@ public static class EmailTemas
 {
     public static string RegistroDeUsuario(string usuario,string codigo)
     {
-      return @$"<!DOCTYPE html>
-          <html lang=""es"">
-          <head>
-            <meta charset=""UTF-8"">
-            <meta name=""viewport"" content=""width=device-width, initial-scale=1.0"">
-            <title>Código de verificación - trivo</title>
-            <script src=""https://cdn.tailwindcss.com""></script>
-            <script>
-              tailwind.config = {{
-                theme: {{
-                  extend: {{
-                    fontFamily: {{
-                      'inter': ['Inter', 'system-ui', 'sans-serif'],
-                    }},
-                    animation: {{
-                      'float': 'float 6s ease-in-out infinite',
-                      'pulse-slow': 'pulse 3s ease-in-out infinite',
-                    }}
-                  }}
-                }}
-              }}
-            </script>
-            <link href=""https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap"" rel=""stylesheet"">
-            <style>
-              @keyframes float {{
-                0%, 100% {{ transform: translateY(0px) rotate(0deg); }}
-                50% {{ transform: translateY(-10px) rotate(2deg); }}
-              }}
-              
-              .gradient-border {{
-                background: linear-gradient(135deg, #8b5cf6, #a855f7, #c084fc);
-                padding: 2px;
-                border-radius: 20px;
-              }}
-              
-              .gradient-border-inner {{
-                background: white;
-                border-radius: 18px;
-              }}
-              
-              .glass-effect {{
-                background: rgba(255, 255, 255, 0.1);
-                backdrop-filter: blur(10px);
-                border: 1px solid rgba(255, 255, 255, 0.2);
-              }}
-              
-              .code-glow {{
-                box-shadow: 0 0 30px rgba(139, 92, 246, 0.3);
-              }}
-            </style>
-          </head>
-          <body class=""font-inter bg-gradient-to-br from-slate-50 via-purple-50 to-indigo-50 min-h-screen"">
+        return $@"<!DOCTYPE html>
+      <html lang=""es"">
+      <head>
+        <meta charset=""UTF-8"">
+        <meta name=""viewport"" content=""width=device-width, initial-scale=1.0"">
+        <title>Código de verificación - trivo</title>
+        <style>
+          @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap');
+          
+          * {{
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+          }}
+          
+          body {{
+            font-family: 'Inter', system-ui, -apple-system, sans-serif;
+            background: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 50%, #e2e8f0 100%);
+            min-height: 100vh;
+            padding: 20px;
+            line-height: 1.6;
+          }}
+          
+          .email-container {{
+            max-width: 600px;
+            margin: 0 auto;
+            background: #ffffff;
+            border-radius: 24px;
+            box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.15);
+            overflow: hidden;
+            position: relative;
+          }}
+          
+          /* Header Styles */
+          .header {{
+            background: linear-gradient(135deg, #8b5cf6 0%, #7c3aed 50%, #6d28d9 100%);
+            padding: 48px 32px;
+            color: white;
+            position: relative;
+            overflow: hidden;
+          }}
+          
+          .header::before {{
+            content: '';
+            position: absolute;
+            top: -50%;
+            right: -20%;
+            width: 200px;
+            height: 200px;
+            background: rgba(255, 255, 255, 0.1);
+            border-radius: 50%;
+            animation: float 6s ease-in-out infinite;
+          }}
+          
+          .header::after {{
+            content: '';
+            position: absolute;
+            bottom: -30%;
+            left: -10%;
+            width: 150px;
+            height: 150px;
+            background: rgba(255, 255, 255, 0.08);
+            border-radius: 50%;
+            animation: float 8s ease-in-out infinite reverse;
+          }}
+          
+          @keyframes float {{
+            0%, 100% {{ transform: translateY(0px) rotate(0deg); }}
+            50% {{ transform: translateY(-20px) rotate(5deg); }}
+          }}
+          
+          .logo-section {{
+            display: flex;
+            align-items: center;
+            gap: 16px;
+            margin-bottom: 32px;
+            position: relative;
+            z-index: 10;
+          }}
+          
+          .logo {{
+            width: 56px;
+            height: 56px;
+            background: rgba(255, 255, 255, 0.15);
+            border-radius: 16px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            backdrop-filter: blur(10px);
+            border: 1px solid rgba(255, 255, 255, 0.2);
+          }}
+          
+          .logo svg {{
+            width: 28px;
+            height: 28px;
+          }}
+          
+          .brand-name {{
+            font-size: 32px;
+            font-weight: 800;
+            letter-spacing: -0.02em;
+          }}
+          
+          .brand-tagline {{
+            font-size: 14px;
+            color: #e9d5ff;
+            font-weight: 500;
+            margin-top: 4px;
+          }}
+          
+          .header-title {{
+            font-size: 42px;
+            font-weight: 800;
+            margin-bottom: 8px;
+            position: relative;
+            z-index: 10;
+            line-height: 1.1;
+          }}
+          
+          .header-subtitle {{
+            font-size: 20px;
+            color: #e9d5ff;
+            font-weight: 500;
+            position: relative;
+            z-index: 10;
+          }}
+          
+          /* Main Content */
+          .content {{
+            padding: 48px 32px;
+          }}
+          
+          .verification-section {{
+            text-align: center;
+            margin-bottom: 40px;
+          }}
+          
+          .icon-wrapper {{
+            width: 80px;
+            height: 80px;
+            background: linear-gradient(135deg, #f3e8ff 0%, #e9d5ff 100%);
+            border-radius: 24px;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            margin-bottom: 24px;
+            position: relative;
+            box-shadow: 0 10px 25px rgba(139, 92, 246, 0.15);
+          }}
+          
+          .icon-wrapper::before {{
+            content: '';
+            position: absolute;
+            inset: 0;
+            background: linear-gradient(135deg, #8b5cf6, #a855f7);
+            border-radius: 24px;
+            opacity: 0.1;
+            animation: pulse 3s ease-in-out infinite;
+          }}
+          
+          @keyframes pulse {{
+            0%, 100% {{ opacity: 0.1; transform: scale(1); }}
+            50% {{ opacity: 0.2; transform: scale(1.05); }}
+          }}
+          
+          .icon-wrapper svg {{
+            width: 40px;
+            height: 40px;
+            color: #8b5cf6;
+            position: relative;
+            z-index: 10;
+          }}
+          
+          .main-title {{
+            font-size: 32px;
+            font-weight: 700;
+            color: #1f2937;
+            margin-bottom: 16px;
+          }}
+          
+          .main-description {{
+            font-size: 18px;
+            color: #6b7280;
+            max-width: 480px;
+            margin: 0 auto;
+            line-height: 1.7;
+          }}
+          
+          /* Code Section */
+          .code-section {{
+            background: linear-gradient(135deg, #faf5ff 0%, #f3e8ff 100%);
+            border-radius: 20px;
+            padding: 40px 32px;
+            margin-bottom: 40px;
+            text-align: center;
+            border: 2px solid #e9d5ff;
+            position: relative;
+            overflow: hidden;
+          }}
+          
+          .code-section::before {{
+            content: '';
+            position: absolute;
+            inset: 0;
+            background: linear-gradient(135deg, #8b5cf6, #a855f7);
+            opacity: 0.03;
+            border-radius: 18px;
+          }}
+          
+          .code-label {{
+            display: inline-block;
+            background: #8b5cf6;
+            color: white;
+            padding: 8px 20px;
+            border-radius: 50px;
+            font-size: 12px;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.1em;
+            margin-bottom: 20px;
+          }}
+          
+          .verification-code {{
+            font-size: 48px;
+            font-weight: 900;
+            color: #6d28d9;
+            letter-spacing: 0.2em;
+            font-family: 'Courier New', monospace;
+            margin-bottom: 16px;
+            text-shadow: 0 2px 4px rgba(139, 92, 246, 0.1);
+          }}
+          
+          .code-expiry {{
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 8px;
+            color: #8b5cf6;
+            font-size: 14px;
+            font-weight: 500;
+          }}
+          
+          .code-expiry svg {{
+            width: 16px;
+            height: 16px;
+          }}
+          
+          /* Instructions */
+          .instructions {{
+            background: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%);
+            border-radius: 16px;
+            padding: 32px;
+            margin-bottom: 32px;
+            border: 1px solid #e2e8f0;
+          }}
+          
+          .instructions-header {{
+            display: flex;
+            align-items: flex-start;
+            gap: 16px;
+            margin-bottom: 20px;
+          }}
+          
+          .check-icon {{
+            width: 32px;
+            height: 32px;
+            background: #10b981;
+            border-radius: 12px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            flex-shrink: 0;
+          }}
+          
+          .check-icon svg {{
+            width: 18px;
+            height: 18px;
+            color: white;
+          }}
+          
+          .instructions-title {{
+            font-size: 20px;
+            font-weight: 700;
+            color: #1f2937;
+            margin-bottom: 16px;
+          }}
+          
+          .steps-list {{
+            list-style: none;
+            padding: 0;
+          }}
+          
+          .step-item {{
+            display: flex;
+            align-items: center;
+            gap: 16px;
+            margin-bottom: 12px;
+            font-size: 16px;
+            color: #4b5563;
+          }}
+          
+          .step-number {{
+            width: 28px;
+            height: 28px;
+            background: #8b5cf6;
+            color: white;
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 12px;
+            font-weight: 700;
+            flex-shrink: 0;
+          }}
+          
+          /* Security Alert */
+          .security-alert {{
+            background: linear-gradient(135deg, #fef3c7 0%, #fde68a 100%);
+            border-left: 4px solid #f59e0b;
+            border-radius: 12px;
+            padding: 24px;
+            margin-bottom: 32px;
+          }}
+          
+          .alert-header {{
+            display: flex;
+            align-items: flex-start;
+            gap: 12px;
+            margin-bottom: 12px;
+          }}
+          
+          .alert-icon {{
+            width: 32px;
+            height: 32px;
+            background: #f59e0b;
+            border-radius: 12px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            flex-shrink: 0;
+          }}
+          
+          .alert-icon svg {{
+            width: 18px;
+            height: 18px;
+            color: white;
+          }}
+          
+          .alert-title {{
+            font-size: 16px;
+            font-weight: 700;
+            color: #92400e;
+          }}
+          
+          .alert-text {{
+            font-size: 14px;
+            color: #b45309;
+            line-height: 1.6;
+          }}
+          
+          /* CTA Button */
+          .cta-section {{
+            text-align: center;
+            margin-bottom: 32px;
+          }}
+          
+          .cta-button {{
+            display: inline-flex;
+            align-items: center;
+            gap: 12px;
+            background: linear-gradient(135deg, #8b5cf6 0%, #7c3aed 50%, #6d28d9 100%);
+            color: white;
+            padding: 18px 36px;
+            border-radius: 16px;
+            font-size: 18px;
+            font-weight: 700;
+            text-decoration: none;
+            box-shadow: 0 10px 25px rgba(139, 92, 246, 0.3);
+            transition: all 0.3s ease;
+            border: none;
+            cursor: pointer;
+          }}
+          
+          .cta-button:hover {{
+            transform: translateY(-2px);
+            box-shadow: 0 15px 35px rgba(139, 92, 246, 0.4);
+          }}
+          
+          .cta-button svg {{
+            width: 20px;
+            height: 20px;
+          }}
+          
+          /* Footer */
+          .footer {{
+            background: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%);
+            padding: 32px;
+            border-top: 1px solid #e2e8f0;
+            text-align: center;
+          }}
+          
+          .footer-text {{
+            font-size: 14px;
+            color: #6b7280;
+            margin-bottom: 16px;
+          }}
+          
+          .footer-text a {{
+            color: #8b5cf6;
+            text-decoration: none;
+            font-weight: 600;
+          }}
+          
+          .footer-text a:hover {{
+            text-decoration: underline;
+          }}
+          
+          .footer-links {{
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 24px;
+            margin-bottom: 24px;
+            font-size: 14px;
+          }}
+          
+          .footer-links a {{
+            color: #6b7280;
+            text-decoration: none;
+            font-weight: 500;
+            transition: color 0.3s ease;
+          }}
+          
+          .footer-links a:hover {{
+            color: #8b5cf6;
+          }}
+          
+          .footer-divider {{
+            width: 4px;
+            height: 4px;
+            background: #d1d5db;
+            border-radius: 50%;
+          }}
+          
+          .copyright {{
+            padding-top: 24px;
+            border-top: 1px solid #e2e8f0;
+          }}
+          
+          .copyright-text {{
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 8px;
+            font-size: 12px;
+            color: #9ca3af;
+          }}
+          
+          .copyright-text svg {{
+            width: 16px;
+            height: 16px;
+          }}
+          
+          /* Responsive Design */
+          @media (max-width: 640px) {{
+            body {{
+              padding: 16px;
+            }}
             
-            <!-- Email Container -->
-            <div class=""max-w-2xl mx-auto p-4 sm:p-8"">
-              
-              <!-- Main Email Card -->
-              <div class=""bg-white rounded-3xl shadow-2xl overflow-hidden relative"">
-                
-                <!-- Floating Elements -->
-                <div class=""absolute top-10 right-10 w-20 h-20 bg-gradient-to-br from-purple-400 to-pink-400 rounded-full opacity-20 animate-float""></div>
-                <div class=""absolute top-32 left-8 w-12 h-12 bg-gradient-to-br from-blue-400 to-purple-400 rounded-full opacity-15 animate-float"" style=""animation-delay: 2s;""></div>
-                <div class=""absolute bottom-20 right-16 w-16 h-16 bg-gradient-to-br from-indigo-400 to-purple-400 rounded-full opacity-10 animate-float"" style=""animation-delay: 4s;""></div>
-                
-                <!-- Header Section -->
-                <div class=""relative bg-gradient-to-br from-purple-600 via-purple-700 to-indigo-800 px-8 py-12 overflow-hidden"">
-                  
-                  <!-- Background Pattern -->
-                  <div class=""absolute inset-0 opacity-10"">
-                    <div class=""absolute top-0 left-0 w-full h-full bg-gradient-to-br from-white/20 to-transparent""></div>
-                    <div class=""absolute top-10 right-10 w-32 h-32 border border-white/20 rounded-full""></div>
-                    <div class=""absolute bottom-10 left-10 w-24 h-24 border border-white/20 rounded-full""></div>
-                  </div>
-                  
-                  <!-- Logo and Brand -->
-                  <div class=""relative z-10"">
-                    <div class=""flex items-center gap-4 mb-8"">
-                      <div class=""w-14 h-14 glass-effect rounded-2xl flex items-center justify-center"">
-                        <svg class=""w-8 h-8 text-white"" fill=""currentColor"" viewBox=""0 0 24 24"">
-                          <path d=""M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z""/>
-                        </svg>
-                      </div>
-                      <div>
-                        <h1 class=""text-3xl font-bold text-white tracking-tight"">trivo</h1>
-                        <p class=""text-purple-200 text-sm font-medium"">Conectando corazones</p>
-                      </div>
-                    </div>
-                    
-                    <div class=""space-y-3"">
-                      <h2 class=""text-4xl font-bold text-white leading-tight"">
-                        {codigo}
-                      </h2>
-                      <p class=""text-purple-100 text-xl font-medium"">
-                        Último paso para unirte a la comunidad
-                      </p>
-                    </div>
-                  </div>
-                </div>
+            .email-container {{
+              border-radius: 16px;
+            }}
+            
+            .header {{
+              padding: 32px 24px;
+            }}
+            
+            .header-title {{
+              font-size: 32px;
+            }}
+            
+            .content {{
+              padding: 32px 24px;
+            }}
+            
+            .verification-code {{
+              font-size: 36px;
+            }}
+            
+            .footer {{
+              padding: 24px;
+            }}
+            
+            .footer-links {{
+              flex-direction: column;
+              gap: 12px;
+            }}
+            
+            .footer-divider {{
+              display: none;
+            }}
+          }}
+        </style>
+      </head>
+      <body>
+        <div class=""email-container"">
+          <!-- Header -->
+          <div class=""header"">
+            <div class=""logo-section"">
+              <div class=""logo"">
+                <svg fill=""currentColor"" viewBox=""0 0 24 24"">
+                  <path d=""M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z""/>
+                </svg>
+              </div>
+              <div>
+                <div class=""brand-name"">trivo</div>
+                <div class=""brand-tagline"">Bienvenido a Trivo {usuario}</div>
+              </div>
+            </div>
+            
+            <h1 class=""header-title"">¡Tu código está aquí! 🎉</h1>
+            <p class=""header-subtitle"">Último paso para unirte a la comunidad</p>
+          </div>
 
-                <!-- Main Content -->
-                <div class=""px-8 py-12 relative"">
-                  
-                  <!-- Welcome Message -->
-                  <div class=""text-center mb-12"">
-                    <div class=""inline-flex items-center justify-center w-20 h-20 bg-gradient-to-br from-purple-100 to-indigo-100 rounded-3xl mb-6 relative"">
-                      <div class=""absolute inset-0 bg-gradient-to-br from-purple-500 to-indigo-500 rounded-3xl opacity-10 animate-pulse-slow""></div>
-                      <svg class=""w-10 h-10 text-purple-600 relative z-10"" fill=""none"" stroke=""currentColor"" viewBox=""0 0 24 24"">
-                        <path stroke-linecap=""round"" stroke-linejoin=""round"" stroke-width=""2"" d=""M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.031 9-11.622 0-1.042-.133-2.052-.382-3.016z""/>
-                      </svg>
-                    </div>
-                    
-                    <h3 class=""text-3xl font-bold text-gray-900 mb-4"">
-                      Verifica tu identidad
-                    </h3>
-                    <p class=""text-gray-600 text-lg leading-relaxed max-w-md mx-auto"">
-                      Ingresa este código en la app para completar tu registro y comenzar a conocer personas increíbles
-                    </p>
-                  </div>
-
-                  <!-- Verification Code Card -->
-                  <div class=""gradient-border mb-12 code-glow"">
-                    <div class=""gradient-border-inner p-8 text-center"">
-                      <div class=""mb-4"">
-                        <span class=""inline-block px-4 py-2 bg-purple-100 text-purple-700 text-sm font-semibold rounded-full uppercase tracking-wider"">
-                          Código de verificación
-                        </span>
-                      </div>
-                      
-                      <div class=""text-5xl font-black text-transparent bg-clip-text bg-gradient-to-r from-purple-600 to-indigo-600 tracking-widest mb-4 font-mono"">
-                        847291
-                      </div>
-                      
-                      <div class=""flex items-center justify-center gap-2 text-purple-600"">
-                        <svg class=""w-4 h-4"" fill=""none"" stroke=""currentColor"" viewBox=""0 0 24 24"">
-                          <path stroke-linecap=""round"" stroke-linejoin=""round"" stroke-width=""2"" d=""M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z""/>
-                        </svg>
-                        <span class=""text-sm font-medium"">Expira en 10 minutos</span>
-                      </div>
-                    </div>
-                  </div>
-
-                  <!-- Instructions -->
-                  <div class=""bg-gradient-to-r from-gray-50 to-purple-50 rounded-2xl p-8 mb-8 border border-gray-100"">
-                    <div class=""flex items-start gap-4"">
-                      <div class=""flex-shrink-0 w-8 h-8 bg-green-100 rounded-xl flex items-center justify-center"">
-                        <svg class=""w-5 h-5 text-green-600"" fill=""none"" stroke=""currentColor"" viewBox=""0 0 24 24"">
-                          <path stroke-linecap=""round"" stroke-linejoin=""round"" stroke-width=""2"" d=""M5 13l4 4L19 7""/>
-                        </svg>
-                      </div>
-                      <div class=""flex-1"">
-                        <h4 class=""text-lg font-bold text-gray-900 mb-3"">Pasos a seguir:</h4>
-                        <div class=""space-y-3"">
-                          <div class=""flex items-center gap-3"">
-                            <span class=""flex-shrink-0 w-6 h-6 bg-purple-600 text-white text-xs font-bold rounded-full flex items-center justify-center"">1</span>
-                            <span class=""text-gray-700"">Abre la aplicación trivo en tu dispositivo</span>
-                          </div>
-                          <div class=""flex items-center gap-3"">
-                            <span class=""flex-shrink-0 w-6 h-6 bg-purple-600 text-white text-xs font-bold rounded-full flex items-center justify-center"">2</span>
-                            <span class=""text-gray-700"">Ingresa el código de 6 dígitos</span>
-                          </div>
-                          <div class=""flex items-center gap-3"">
-                            <span class=""flex-shrink-0 w-6 h-6 bg-purple-600 text-white text-xs font-bold rounded-full flex items-center justify-center"">3</span>
-                            <span class=""text-gray-700"">¡Comienza tu aventura de conexiones!</span>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-
-                  <!-- Security Alert -->
-                  <div class=""bg-gradient-to-r from-amber-50 to-orange-50 border-l-4 border-amber-400 rounded-xl p-6 mb-8"">
-                    <div class=""flex items-start gap-3"">
-                      <div class=""flex-shrink-0 w-8 h-8 bg-amber-100 rounded-xl flex items-center justify-center"">
-                        <svg class=""w-5 h-5 text-amber-600"" fill=""none"" stroke=""currentColor"" viewBox=""0 0 24 24"">
-                          <path stroke-linecap=""round"" stroke-linejoin=""round"" stroke-width=""2"" d=""M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z""/>
-                        </svg>
-                      </div>
-                      <div>
-                        <h4 class=""font-bold text-amber-800 mb-2"">🔒 Protege tu cuenta</h4>
-                        <p class=""text-amber-700 text-sm leading-relaxed"">
-                          Este código es personal e intransferible. Nunca lo compartas con terceros. 
-                          El equipo de trivo jamás te solicitará este código por teléfono o email.
-                        </p>
-                      </div>
-                    </div>
-                  </div>
-
-                  <!-- CTA Button -->
-                  <div class=""text-center mb-8"">
-                    <a href=""#"" class=""inline-flex items-center gap-3 bg-gradient-to-r from-purple-600 via-purple-700 to-indigo-700 hover:from-purple-700 hover:via-purple-800 hover:to-indigo-800 text-white px-10 py-5 rounded-2xl font-bold text-lg shadow-xl hover:shadow-2xl transition-all duration-300 transform hover:scale-105 hover:-translate-y-1"">
-                      <svg class=""w-6 h-6"" fill=""none"" stroke=""currentColor"" viewBox=""0 0 24 24"">
-                        <path stroke-linecap=""round"" stroke-linejoin=""round"" stroke-width=""2"" d=""M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14""/>
-                      </svg>
-                      Abrir trivo ahora
-                    </a>
-                  </div>
-                </div>
-
-                <!-- Footer -->
-                <div class=""bg-gradient-to-r from-gray-50 to-purple-50 px-8 py-8 border-t border-gray-100"">
-                  <div class=""text-center space-y-6"">
-                    
-                    <!-- Help Text -->
-                    <p class=""text-gray-600 text-sm"">
-                      ¿No solicitaste este código? 
-                      <a href=""#"" class=""text-purple-600 hover:text-purple-700 font-medium underline"">
-                        Reporta actividad sospechosa
-                      </a>
-                    </p>
-                    
-                    <!-- Links -->
-                    <div class=""flex items-center justify-center gap-8 text-sm"">
-                      <a href=""#"" class=""text-gray-500 hover:text-purple-600 transition-colors font-medium"">
-                        Centro de ayuda
-                      </a>
-                      <div class=""w-1 h-1 bg-gray-300 rounded-full""></div>
-                      <a href=""#"" class=""text-gray-500 hover:text-purple-600 transition-colors font-medium"">
-                        Soporte técnico
-                      </a>
-                      <div class=""w-1 h-1 bg-gray-300 rounded-full""></div>
-                      <a href=""#"" class=""text-gray-500 hover:text-purple-600 transition-colors font-medium"">
-                        Privacidad
-                      </a>
-                    </div>
-                    
-                    <!-- Copyright -->
-                    <div class=""pt-6 border-t border-gray-200"">
-                      <div class=""flex items-center justify-center gap-2 text-gray-400 text-xs"">
-                        <svg class=""w-4 h-4"" fill=""currentColor"" viewBox=""0 0 24 24"">
-                          <path d=""M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z""/>
-                        </svg>
-                        <span>© 2024 trivo • Conectando corazones, creando historias</span>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                
+          <!-- Main Content -->
+          <div class=""content"">
+            <!-- Verification Section -->
+            <div class=""verification-section"">
+              <div class=""icon-wrapper"">
+                <svg fill=""none"" stroke=""currentColor"" viewBox=""0 0 24 24"">
+                  <path stroke-linecap=""round"" stroke-linejoin=""round"" stroke-width=""2"" d=""M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.031 9-11.622 0-1.042-.133-2.052-.382-3.016z""/>
+                </svg>
               </div>
               
-              <!-- Bottom Spacing -->
-              <div class=""h-8""></div>
-              
+              <h2 class=""main-title"">Verifica tu identidad</h2>
+              <p class=""main-description"">
+                Ingresa este código en la app para completar tu registro y comenzar a conocer personas increíbles
+              </p>
             </div>
 
-          </body>
-          </html>";
+            <!-- Verification Code -->
+            <div class=""code-section"">
+              <div class=""code-label"">Código de verificación</div>
+              <div class=""verification-code"">{codigo}</div>
+              <div class=""code-expiry"">
+                <svg fill=""none"" stroke=""currentColor"" viewBox=""0 0 24 24"">
+                  <path stroke-linecap=""round"" stroke-linejoin=""round"" stroke-width=""2"" d=""M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z""/>
+                </svg>
+                <span>Expira en 10 minutos</span>
+              </div>
+            </div>
+
+            <!-- Instructions -->
+            <div class=""instructions"">
+              <div class=""instructions-header"">
+                <div class=""check-icon"">
+                  <svg fill=""none"" stroke=""currentColor"" viewBox=""0 0 24 24"">
+                    <path stroke-linecap=""round"" stroke-linejoin=""round"" stroke-width=""2"" d=""M5 13l4 4L19 7""/>
+                  </svg>
+                </div>
+                <div>
+                  <h3 class=""instructions-title"">Pasos a seguir:</h3>
+                  <ul class=""steps-list"">
+                    <li class=""step-item"">
+                      <span class=""step-number"">1</span>
+                      <span>Abre la aplicación trivo en tu dispositivo</span>
+                    </li>
+                    <li class=""step-item"">
+                      <span class=""step-number"">2</span>
+                      <span>Ingresa el código de 6 dígitos</span>
+                    </li>
+                    <li class=""step-item"">
+                      <span class=""step-number"">3</span>
+                      <span>¡Comienza tu aventura de conexiones!</span>
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+
+            <!-- Security Alert -->
+            <div class=""security-alert"">
+              <div class=""alert-header"">
+                <div class=""alert-icon"">
+                  <svg fill=""none"" stroke=""currentColor"" viewBox=""0 0 24 24"">
+                    <path stroke-linecap=""round"" stroke-linejoin=""round"" stroke-width=""2"" d=""M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z""/>
+                  </svg>
+                </div>
+                <div>
+                  <h4 class=""alert-title"">🔒 Protege tu cuenta</h4>
+                </div>
+              </div>
+              <p class=""alert-text"">
+                Este código es personal e intransferible. Nunca lo compartas con terceros. 
+                El equipo de trivo jamás te solicitará este código por teléfono o email.
+              </p>
+            </div>
+
+          <!-- Footer -->
+          <div class=""footer"">
+            <p class=""footer-text"">
+              ¿No solicitaste este código? 
+              <a href=""#"">Reporta actividad sospechosa</a>
+            </p>
+            
+            <div class=""footer-links"">
+              <a href=""#"">Centro de ayuda</a>
+              <div class=""footer-divider""></div>
+              <a href=""#"">Soporte técnico</a>
+              <div class=""footer-divider""></div>
+              <a href=""#"">Privacidad</a>
+            </div>
+            
+            <div class=""copyright"">
+              <div class=""copyright-text"">
+                <svg fill=""currentColor"" viewBox=""0 0 24 24"">
+                  <path d=""M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z""/>
+                </svg>
+                <span>© 2024 trivo • Conectando corazones, creando historias</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </body>
+      </html>";
     }
 
     public static string OlvidarContrasena(string code, string nombreUsuario)

--- a/Trivo.Infraestructura.Persistencia/Base/Validacion.cs
+++ b/Trivo.Infraestructura.Persistencia/Base/Validacion.cs
@@ -1,0 +1,19 @@
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore;
+using Trivo.Aplicacion.Interfaces.Base;
+using Trivo.Infraestructura.Persistencia.Contexto;
+
+namespace Trivo.Infraestructura.Persistencia.Base;
+
+public class Validacion<TEntidad>(TrivoContexto trivoContexto) : IValidacion
+    <TEntidad> where TEntidad : class
+{
+    protected readonly TrivoContexto _trivoContexto = trivoContexto;
+    
+    public async Task<bool> Validar(Expression<Func<TEntidad, bool>> entidadExpresion, CancellationToken cancellationToken)
+    {
+        return await _trivoContexto.Set<TEntidad>()
+            .AsNoTracking()
+            .AnyAsync(entidadExpresion, cancellationToken);
+    }
+}

--- a/Trivo.Infraestructura.Persistencia/InyeccionDeDependencia.cs
+++ b/Trivo.Infraestructura.Persistencia/InyeccionDeDependencia.cs
@@ -1,8 +1,10 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Trivo.Aplicacion.Interfaces.Base;
 using Trivo.Aplicacion.Interfaces.Repositorio;
 using Trivo.Aplicacion.Interfaces.Repositorio.Cuenta;
+using Trivo.Infraestructura.Persistencia.Base;
 using Trivo.Infraestructura.Persistencia.Contexto;
 using Trivo.Infraestructura.Persistencia.Repositorio;
 using Trivo.Infraestructura.Persistencia.Repositorio.Cuenta;
@@ -39,6 +41,7 @@ public static class InyeccionDeDependencia
         #region ID
 
         servicio.AddTransient(typeof(IRepositorioGenerico<>), typeof(RepositorioGenerico<>));
+        servicio.AddTransient(typeof(IValidacion<>), typeof(Validacion<>));
         servicio.AddTransient<IRepositorioAdministrador, RepositorioAdministrador>();
         servicio.AddTransient<IRepositorioExperto, RepositorioExperto>();
         servicio.AddTransient<IRepositorioReclutador, RepositorioReclutador>();

--- a/Trivo.Infraestructura.Persistencia/Repositorio/RepositorioCategoriaInteres.cs
+++ b/Trivo.Infraestructura.Persistencia/Repositorio/RepositorioCategoriaInteres.cs
@@ -1,31 +1,33 @@
+using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore;
 using Trivo.Aplicacion.Interfaces.Repositorio;
 using Trivo.Aplicacion.Paginacion;
 using Trivo.Dominio.Modelos;
+using Trivo.Infraestructura.Persistencia.Base;
 using Trivo.Infraestructura.Persistencia.Contexto;
 
 namespace Trivo.Infraestructura.Persistencia.Repositorio;
 
-public class RepositorioCategoriaInteres(TrivoContexto trivoContexto) : IRepositorioCategoriaInteres
+public class RepositorioCategoriaInteres(TrivoContexto trivoContexto) : Validacion<CategoriaInteres>(trivoContexto),IRepositorioCategoriaInteres
 {
     public async Task CrearCategoriaInteresAsync(CategoriaInteres categorias, CancellationToken cancellationToken)
     {
-        await trivoContexto.Set<CategoriaInteres>().AddAsync(categorias, cancellationToken);
-        await trivoContexto.SaveChangesAsync(cancellationToken);
+        await _trivoContexto.Set<CategoriaInteres>().AddAsync(categorias, cancellationToken);
+        await _trivoContexto.SaveChangesAsync(cancellationToken);
     }
 
     public async Task<CategoriaInteres> ObtenerPorIdAsync(Guid categoriaInteresId, CancellationToken cancellationToken)
     {
-        return (await trivoContexto.Set<CategoriaInteres>()
+        return (await _trivoContexto.Set<CategoriaInteres>()
             .AsNoTracking()
             .FirstOrDefaultAsync(ci => ci.CategoriaId == categoriaInteresId, cancellationToken))!;
     }
 
     public async Task<ResultadoPaginado<CategoriaInteres>> ObtenerCategoriaInteresPaginadoAsync(int numeroPagina, int tamanoPagina, CancellationToken cancellationToken)
     {
-        var total = await trivoContexto.Set<CategoriaInteres>().AsNoTracking().CountAsync(cancellationToken);
+        var total = await _trivoContexto.Set<CategoriaInteres>().AsNoTracking().CountAsync(cancellationToken);
             
-        var categoriaInteres = await trivoContexto.Set<CategoriaInteres>().AsNoTracking()
+        var categoriaInteres = await _trivoContexto.Set<CategoriaInteres>().AsNoTracking()
             .Skip((numeroPagina - 1) * tamanoPagina)
             .Take(tamanoPagina)
             .ToListAsync(cancellationToken);
@@ -35,8 +37,14 @@ public class RepositorioCategoriaInteres(TrivoContexto trivoContexto) : IReposit
 
     public async Task ActualizarCategoriaInteresAsync(CategoriaInteres categoriaInteres, CancellationToken cancellationToken)
     {
-        trivoContexto.Set<CategoriaInteres>().Attach(categoriaInteres);
-        trivoContexto.Entry(categoriaInteres).State = EntityState.Modified;
-        await trivoContexto.SaveChangesAsync(cancellationToken);
+        _trivoContexto.Set<CategoriaInteres>().Attach(categoriaInteres);
+        _trivoContexto.Entry(categoriaInteres).State = EntityState.Modified;
+        await _trivoContexto.SaveChangesAsync(cancellationToken);
     }
+
+    public async Task<bool> NombreExisteAsync(string nombre, CancellationToken cancellationToken)
+    {
+        return await Validar(x => x.Nombre == nombre, cancellationToken);
+    }
+    
 }

--- a/Trivo.Infraestructura.Persistencia/Repositorio/RepositorioHabilidad.cs
+++ b/Trivo.Infraestructura.Persistencia/Repositorio/RepositorioHabilidad.cs
@@ -1,22 +1,24 @@
+using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore;
 using Trivo.Aplicacion.Interfaces.Repositorio;
 using Trivo.Aplicacion.Paginacion;
 using Trivo.Dominio.Modelos;
+using Trivo.Infraestructura.Persistencia.Base;
 using Trivo.Infraestructura.Persistencia.Contexto;
 
 namespace Trivo.Infraestructura.Persistencia.Repositorio;
 
-public class RepositorioHabilidad(TrivoContexto trivoContexto) : IRepositorioHabilidad
+public class RepositorioHabilidad(TrivoContexto trivoContexto) : Validacion<Habilidad>(trivoContexto),IRepositorioHabilidad
 {
     public async Task CrearHabilidadAsync(Habilidad habilidades, CancellationToken cancellationToken)
     {
-        await trivoContexto.Set<Habilidad>().AddAsync(habilidades, cancellationToken);
-        await trivoContexto.SaveChangesAsync(cancellationToken);
+        await _trivoContexto.Set<Habilidad>().AddAsync(habilidades, cancellationToken);
+        await _trivoContexto.SaveChangesAsync(cancellationToken);
     }
 
     public async Task ActualizarHabilidadAsync(Guid usuarioId, List<Guid> habilidadIds ,CancellationToken cancellationToken)
     {
-        var interesesActualesIds = await trivoContexto.Set<UsuarioHabilidad>()
+        var interesesActualesIds = await _trivoContexto.Set<UsuarioHabilidad>()
             .Where(ui => ui.UsuarioId == usuarioId)
             .Select(ui => ui.HabilidadId!.Value)
             .ToListAsync(cancellationToken);
@@ -26,11 +28,11 @@ public class RepositorioHabilidad(TrivoContexto trivoContexto) : IRepositorioHab
         var interesesNuevos = habilidadIds.Except(interesesActualesIds);
 
         // Eliminar solo los que ya no están
-        var relacionesAEliminar = await trivoContexto.Set<UsuarioHabilidad>()
+        var relacionesAEliminar = await _trivoContexto.Set<UsuarioHabilidad>()
             .Where(ui => ui.UsuarioId == usuarioId && interesesAEliminar.Contains(ui.HabilidadId!.Value))
             .ToListAsync(cancellationToken);
 
-        trivoContexto.Set<UsuarioHabilidad>().RemoveRange(relacionesAEliminar);
+        _trivoContexto.Set<UsuarioHabilidad>().RemoveRange(relacionesAEliminar);
 
         var relacionesANuevas = interesesNuevos.Select(id => new UsuarioHabilidad
         {
@@ -38,16 +40,16 @@ public class RepositorioHabilidad(TrivoContexto trivoContexto) : IRepositorioHab
             HabilidadId = id
         });
 
-        await trivoContexto.Set<UsuarioHabilidad>().AddRangeAsync(relacionesANuevas, cancellationToken);
+        await _trivoContexto.Set<UsuarioHabilidad>().AddRangeAsync(relacionesANuevas, cancellationToken);
         
-        await trivoContexto.SaveChangesAsync(cancellationToken);
+        await _trivoContexto.SaveChangesAsync(cancellationToken);
     }
 
     public async Task<ResultadoPaginado<Habilidad>> ObtenerHabilidadPaginadoAsync(int numeroPagina, int tamanoPagina, CancellationToken cancellationToken)
     {
-        var total = await trivoContexto.Set<Habilidad>().AsNoTracking().CountAsync(cancellationToken);
+        var total = await _trivoContexto.Set<Habilidad>().AsNoTracking().CountAsync(cancellationToken);
             
-        var habilidad = await trivoContexto.Set<Habilidad>().AsNoTracking()
+        var habilidad = await _trivoContexto.Set<Habilidad>().AsNoTracking()
             .Skip((numeroPagina - 1) * tamanoPagina)
             .Take(tamanoPagina)
             .ToListAsync(cancellationToken);
@@ -57,13 +59,13 @@ public class RepositorioHabilidad(TrivoContexto trivoContexto) : IRepositorioHab
 
     public async Task<Habilidad> ObtenerHabilidadPorIdAsync(Guid habilidadId, CancellationToken cancellationToken)
     {
-        return (await trivoContexto.Set<Habilidad>()
+        return (await _trivoContexto.Set<Habilidad>()
             .FirstOrDefaultAsync(x => x.HabilidadId == habilidadId, cancellationToken))!;
     }
 
     public async Task<IEnumerable<Usuario>> ObtenerUsuariosPorHabilidadesAsync(IEnumerable<Guid> habilidadId, CancellationToken cancellationToken)
     {
-        return await trivoContexto.Set<Usuario>()
+        return await _trivoContexto.Set<Usuario>()
             .AsNoTracking()
             .Include(u => u.UsuarioHabilidades!)
                 .ThenInclude(uh => uh.Habilidad)
@@ -73,4 +75,10 @@ public class RepositorioHabilidad(TrivoContexto trivoContexto) : IRepositorioHab
             .AsSingleQuery()
             .ToListAsync(cancellationToken);
     }
+
+    public async Task<bool> NombreExisteAsync(string nombre, CancellationToken cancellationToken)
+    {
+        return await Validar(x => x.Nombre == nombre, cancellationToken);
+    }
+    
 }


### PR DESCRIPTION
# feat: add validators and email template

## Summary

This pull request introduces key improvements to the validation system and user communication templates. Specifically:

- ✅ Added FluentValidation validators for:
  - Category (`CategoriaInteres`)
  - Ability (`Habilidad`)
  - Interest (`Interes`)
- ✅ Implemented a standardized `IValidator` interface across the above validators for consistency and reusability.
- ✅ Introduced a reusable validation method to prevent duplication (e.g., name conflicts).
- ✅ Added a user confirmation email template for registration.

## Commits

- `feat: add category validator`
- `feat: add ability validator`
- `feat: add interest validator`
- `feat: add email template for user confirmation`
- `refactor: apply IValidator interface to category, ability and interest validators`
