### PR TITLE
Add User Filtering by Interests and Skills

### DIFF
--- a/Trivo.Aplicacion/DTOs/Cuentas/Usuarios/ParametroUsuariFiltroHabilidadesInteres.cs
+++ b/Trivo.Aplicacion/DTOs/Cuentas/Usuarios/ParametroUsuariFiltroHabilidadesInteres.cs
@@ -1,0 +1,3 @@
+namespace Trivo.Aplicacion.DTOs.Cuentas.Usuarios;
+
+public sealed record ParametroUsuariFiltroHabilidadesInteres(List<Guid> InteresIds, List<Guid> HabilidadIds);

--- a/Trivo.Aplicacion/Interfaces/Repositorio/Cuenta/IRepositorioUsuario.cs
+++ b/Trivo.Aplicacion/Interfaces/Repositorio/Cuenta/IRepositorioUsuario.cs
@@ -47,21 +47,17 @@ public interface IRepositorioUsuario: IRepositorioGenerico<Usuario>
     Task<Usuario> BuscarPorNombreUsuarioAsync(string nombreUsuario, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Filtra usuarios que tengan las habilidades indicadas.
+    /// Filtra y obtiene los usuarios que tienen al menos uno de los intereses o habilidades especificados.
     /// </summary>
-    /// <param name="habilidadesIds">Lista de Ids de habilidades.</param>
-    /// <param name="cancellationToken">Token para cancelar la operacion.</param>
-    /// <returns>Lista de usuarios que cumplen el filtro.</returns>
-    Task<IEnumerable<Usuario>> FiltrarPorHabilidadesAsync(List<Guid> habilidadesIds, CancellationToken cancellationToken);
-
-    /// <summary>
-    /// Filtra usuarios que tengan los intereses indicados.
-    /// </summary>
-    /// <param name="interesesIds">Lista de Ids de intereses.</param>
-    /// <param name="cancellationToken">Token para cancelar la operacion.</param>
-    /// <returns>Lista de usuarios que cumplen el filtro.</returns>
-    Task<IEnumerable<Usuario>> FiltrarPorInteresesAsync(List<Guid> interesesIds, CancellationToken cancellationToken);
-
+    /// <param name="interesesIds">Lista opcional de IDs de intereses para filtrar.</param>
+    /// <param name="habilidadesIds">Lista opcional de IDs de habilidades para filtrar.</param>
+    /// <param name="cancellationToken">Token para cancelar la operación asincrónica.</param>
+    /// <returns>Una colección de objetos <see cref="Usuario"/> que coinciden con los intereses o habilidades especificados.</returns>
+    Task<IEnumerable<Usuario>> FiltrarPorInteresesYHabilidadesAsync(
+        List<Guid>? interesesIds,
+        List<Guid>? habilidadesIds,
+        CancellationToken cancellationToken);
+    
     /// <summary>
     /// Obtiene las habilidades de un usuario dado su Id.
     /// </summary>
@@ -130,16 +126,40 @@ public interface IRepositorioUsuario: IRepositorioGenerico<Usuario>
     /// <param name="cancellationToken">Token para cancelar la operación asíncrona.</param>
     /// <returns>Una colección de usuarios con sus intereses.</returns>
     Task<IEnumerable<Usuario>> ObtenerTodosUsuariosConInteresesYHabilidades(CancellationToken cancellationToken);
-
-
+    
+   /// <summary>
+    /// Obtiene la lista de intereses asociados a un usuario específico.
+    /// </summary>
+    /// <param name="usuarioId">El ID del usuario.</param>
+    /// <param name="cancellationToken">Token para cancelar la operación asincrónica.</param>
+    /// <returns>Una colección de objetos <see cref="UsuarioInteres"/>.</returns>
     Task<IEnumerable<UsuarioInteres>> ObtenerInteresesPorUsuarioIdAsync(Guid usuarioId,
         CancellationToken cancellationToken);
-    
+
+    /// <summary>
+    /// Obtiene la lista de habilidades asociadas a un usuario específico.
+    /// </summary>
+    /// <param name="usuarioId">El ID del usuario.</param>
+    /// <param name="cancellationToken">Token para cancelar la operación asincrónica.</param>
+    /// <returns>Una colección de objetos <see cref="UsuarioHabilidad"/>.</returns>
     Task<IEnumerable<UsuarioHabilidad>> ObtenerHabilidadesPorUsuarioIdAsync(Guid usuarioId,
         CancellationToken cancellationToken);
-    
+
+    /// <summary>
+    /// Obtiene la lista de usuarios potenciales para emparejamiento, basada en el rol y el ID del usuario actual.
+    /// </summary>
+    /// <param name="usuarioActualId">El ID del usuario que realiza la búsqueda.</param>
+    /// <param name="rol">El rol del usuario para filtrar los objetivos (por ejemplo: "Experto", "Aprendiz").</param>
+    /// <param name="cancellationToken">Token para cancelar la operación asincrónica.</param>
+    /// <returns>Una colección de objetos <see cref="Usuario"/> como objetivos posibles.</returns>
     Task<IEnumerable<Usuario>> ObtenerUsuariosObjetivoAsync(Guid usuarioActualId, string rol,
         CancellationToken cancellationToken);
-    
+
+    /// <summary>
+    /// Obtiene el rol asignado a un usuario específico.
+    /// </summary>
+    /// <param name="usuarioId">El ID del usuario.</param>
+    /// <param name="cancellationToken">Token para cancelar la operación asincrónica.</param>
+    /// <returns>Una cadena que representa el rol del usuario.</returns>
     Task<string> ObtenerRolDeUsuarioAsync(Guid usuarioId, CancellationToken cancellationToken);
 }

--- a/Trivo.Aplicacion/Modulos/Usuario/Querys/ObtenerUsuariosPorHabilidadesInteres/ObtenerUsuariosPorInteresesYHabilidadesQuery.cs
+++ b/Trivo.Aplicacion/Modulos/Usuario/Querys/ObtenerUsuariosPorHabilidadesInteres/ObtenerUsuariosPorInteresesYHabilidadesQuery.cs
@@ -1,0 +1,13 @@
+using Trivo.Aplicacion.Abstracciones.Mensajes;
+using Trivo.Aplicacion.DTOs.Cuentas.Usuarios;
+using Trivo.Aplicacion.Paginacion;
+
+namespace Trivo.Aplicacion.Modulos.Usuario.Querys.ObtenerUsuariosPorHabilidadesInteres;
+
+public sealed record ObtenerUsuariosPorInteresesYHabilidadesQuery
+(
+    int NumeroPagina,
+    int TamanoPagina,
+    List<Guid> HabilidadesIds,
+    List<Guid> InteresesIds
+) : IQuery<ResultadoPaginado<UsuarioReconmendacionDto>>;

--- a/Trivo.Aplicacion/Modulos/Usuario/Querys/ObtenerUsuariosPorHabilidadesInteres/ObtenerUsuariosPorInteresesYHabilidadesQueryHandler.cs
+++ b/Trivo.Aplicacion/Modulos/Usuario/Querys/ObtenerUsuariosPorHabilidadesInteres/ObtenerUsuariosPorInteresesYHabilidadesQueryHandler.cs
@@ -1,0 +1,80 @@
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Logging;
+using Trivo.Aplicacion.Abstracciones.Mensajes;
+using Trivo.Aplicacion.DTOs.Cuentas.Usuarios;
+using Trivo.Aplicacion.Interfaces.Repositorio;
+using Trivo.Aplicacion.Interfaces.Repositorio.Cuenta;
+using Trivo.Aplicacion.Mapper;
+using Trivo.Aplicacion.Paginacion;
+using Trivo.Aplicacion.Utilidades;
+
+namespace Trivo.Aplicacion.Modulos.Usuario.Querys.ObtenerUsuariosPorHabilidadesInteres;
+
+internal sealed class ObtenerUsuariosPorInteresesYHabilidadesQueryHandler(
+    ILogger<ObtenerUsuariosPorInteresesYHabilidadesQueryHandler> logger,
+    IRepositorioUsuario repositorioUsuario,
+    IDistributedCache cache
+    ) : IQueryHandler<
+    ObtenerUsuariosPorInteresesYHabilidadesQuery, ResultadoPaginado<UsuarioReconmendacionDto>>
+{
+    public async Task<ResultadoT<ResultadoPaginado<UsuarioReconmendacionDto>>> Handle(
+        ObtenerUsuariosPorInteresesYHabilidadesQuery request, CancellationToken cancellationToken)
+    {
+        if (request is { TamanoPagina: <= 0, NumeroPagina: <= 0 })
+        {
+            logger.LogWarning("Tamaño o número de página inválidos: TamañoPagina={Tamano}, NumeroPagina={Numero}",
+                request.TamanoPagina, request.NumeroPagina);
+            
+            return ResultadoT<ResultadoPaginado<UsuarioReconmendacionDto>>.Fallo(
+                Error.Fallo("400", "El número y tamaño de página deben ser mayores a cero."));
+        }
+
+        if (!request.HabilidadesIds.Any() || !request.InteresesIds.Any())
+        {
+            logger.LogWarning("Lista de intereses o habilidades vacía.");
+        
+            return ResultadoT<ResultadoPaginado<UsuarioReconmendacionDto>>.Fallo(
+                Error.Fallo("400", "Debe especificar al menos un interés y una habilidad."));
+        }
+
+        var usuariosConInteresYHabilidades = await repositorioUsuario
+            .FiltrarPorInteresesYHabilidadesAsync(request.InteresesIds, request.HabilidadesIds, cancellationToken);
+
+        var usuariosList = usuariosConInteresYHabilidades as IList<Dominio.Modelos.Usuario> ?? usuariosConInteresYHabilidades.ToList();
+
+        if (!usuariosList.Any())
+        {
+            logger.LogWarning("No se encontraron usuarios que coincidan con los intereses y habilidades proporcionados.");
+            
+            return ResultadoT<ResultadoPaginado<UsuarioReconmendacionDto>>.Fallo(
+                Error.NoEncontrado("404", "No se encontraron usuarios con los intereses y habilidades especificados."));
+        }
+        
+        var cacheLlave = $"usuarios-intereses-habilidades:{string.Join("-", request.InteresesIds)}:{string.Join("-", request.HabilidadesIds)}:{request.NumeroPagina}:{request.TamanoPagina}";
+        
+        var resultadoPaginado = await cache.ObtenerOCrearAsync(
+            cacheLlave,
+            async () =>
+            {
+                var usuariosDto = usuariosList
+                    .Select(UsuarioMapper.MapToDto)
+                    .ToList();
+
+                var total = usuariosDto.Count;
+
+                var paginados = usuariosDto
+                    .Paginar(request.NumeroPagina, request.TamanoPagina)
+                    .ToList();
+
+                return new ResultadoPaginado<UsuarioReconmendacionDto>(paginados, total, request.NumeroPagina, request.TamanoPagina);
+            },
+            cancellationToken: cancellationToken
+        );
+        
+        logger.LogInformation("Usuarios filtrados exitosamente por intereses y habilidades. Total encontrados: {TotalUsuarios}",
+            resultadoPaginado.TotalElementos);
+
+        return ResultadoT<ResultadoPaginado<UsuarioReconmendacionDto>>.Exito(resultadoPaginado);
+    }
+
+}

--- a/Trivo.Infraestructura.Persistencia/Repositorio/Cuenta/RepositorioUsuario.cs
+++ b/Trivo.Infraestructura.Persistencia/Repositorio/Cuenta/RepositorioUsuario.cs
@@ -149,7 +149,6 @@ public class RepositorioUsuario(TrivoContexto trivoContexto) :
             .Where(u => usuarioIds.Contains(u.Id ?? Guid.Empty))
             .ToListAsync(cancellationToken);
     }
-
     
     public async Task<Usuario?> ObtenerUsuarioConInteresYHabilidades(Guid usuarioId, CancellationToken cancellationToken)
     {

--- a/Trivo.Infraestructura.Persistencia/Repositorio/Cuenta/RepositorioUsuario.cs
+++ b/Trivo.Infraestructura.Persistencia/Repositorio/Cuenta/RepositorioUsuario.cs
@@ -107,37 +107,50 @@ public class RepositorioUsuario(TrivoContexto trivoContexto) :
             .FirstOrDefaultAsync(cancellationToken))!;
     }
 
-
-    public async Task<IEnumerable<Usuario>> FiltrarPorHabilidadesAsync(List<Guid> habilidadesIds, CancellationToken cancellationToken)
+    
+    public async Task<IEnumerable<Usuario>> FiltrarPorInteresesYHabilidadesAsync(
+        List<Guid>? interesesIds,
+        List<Guid>? habilidadesIds,
+        CancellationToken cancellationToken)
     {
-        var usuarioIds = await _trivoContexto.Set<UsuarioHabilidad>()
-            .AsNoTracking()
-            .Where(uh => habilidadesIds.Contains(uh.HabilidadId!.Value))
-            .Select(uh => uh.UsuarioId)
-            .Distinct()
-            .ToListAsync(cancellationToken);
+        var usuarioIds = new HashSet<Guid>();
+
+        if (interesesIds is not null && interesesIds.Any())
+        {
+            var usuariosConIntereses = await _trivoContexto.Set<UsuarioInteres>()
+                .AsNoTracking()
+                .Where(ui => interesesIds.Contains(ui.InteresId!.Value))
+                .Select(ui => ui.UsuarioId)
+                .Distinct()
+                .ToListAsync(cancellationToken);
+
+            foreach (var id in usuariosConIntereses)
+                usuarioIds.Add(id ?? Guid.Empty);
+        }
+
+        if (habilidadesIds is not null && habilidadesIds.Any())
+        {
+            var usuariosConHabilidades = await _trivoContexto.Set<UsuarioHabilidad>()
+                .AsNoTracking()
+                .Where(uh => habilidadesIds.Contains(uh.HabilidadId!.Value))
+                .Select(uh => uh.UsuarioId)
+                .Distinct()
+                .ToListAsync(cancellationToken);
+
+            foreach (var id in usuariosConHabilidades)
+                usuarioIds.Add(id ?? Guid.Empty);
+        }
+
+        if (usuarioIds.Count == 0)
+            return [];
 
         return await _trivoContexto.Set<Usuario>()
             .AsNoTracking()
-            .Where(u => usuarioIds.Contains(u.Id))
+            .Where(u => usuarioIds.Contains(u.Id ?? Guid.Empty))
             .ToListAsync(cancellationToken);
     }
 
-    public async Task<IEnumerable<Usuario>> FiltrarPorInteresesAsync(List<Guid> interesesIds, CancellationToken cancellationToken)
-    {
-        var usuarioIdsConIntereses = await _trivoContexto.Set<UsuarioInteres>()
-            .AsNoTracking()
-            .Where(ui => interesesIds.Contains(ui.InteresId!.Value))
-            .Select(ui => ui.UsuarioId)
-            .Distinct()
-            .ToListAsync(cancellationToken);
-
-        return await _trivoContexto.Set<Usuario>()
-            .AsNoTracking()
-            .Where(u => usuarioIdsConIntereses.Contains(u.Id))
-            .ToListAsync(cancellationToken);
-       
-    }
+    
     public async Task<Usuario?> ObtenerUsuarioConInteresYHabilidades(Guid usuarioId, CancellationToken cancellationToken)
     {
         return await _trivoContexto.Set<Usuario>()

--- a/Trivo.Presentacion.API/Controllers/V1/UsuarioControlador.cs
+++ b/Trivo.Presentacion.API/Controllers/V1/UsuarioControlador.cs
@@ -23,6 +23,7 @@ using Trivo.Aplicacion.Modulos.Usuario.Querys.ObtenerFotoDePerfil;
 using Trivo.Aplicacion.Modulos.Usuario.Querys.ObtenerHabilidades;
 using Trivo.Aplicacion.Modulos.Usuario.Querys.ObtenerInteres;
 using Trivo.Aplicacion.Modulos.Usuario.Querys.ObtenerRecomendacionUsuarios;
+using Trivo.Aplicacion.Modulos.Usuario.Querys.ObtenerUsuariosPorHabilidadesInteres;
 
 namespace Trivo.Presentacion.API.Controllers.V1;
 
@@ -271,5 +272,25 @@ public class UsuarioControlador(IMediator mediator, IValidarCorreo validarCorreo
 
         return Ok(resultado.Valor);
     }
-    
+
+    [HttpPost("filter-by-interests-and-ability")]
+    public async Task<IActionResult> ObtenerUsuariosPorInteresesYHabilidades(
+        [FromBody] ParametroUsuariFiltroHabilidadesInteres usuarisHabilidadesInteres,
+        [FromQuery] int numeroPagina,
+        [FromQuery] int tamanoPagina, 
+        CancellationToken cancellationToken
+        )
+    {
+        ObtenerUsuariosPorInteresesYHabilidadesQuery query = new(
+            numeroPagina,
+            tamanoPagina,
+            usuarisHabilidadesInteres.HabilidadIds,
+            usuarisHabilidadesInteres.InteresIds);
+        
+        var resultado = await mediator.Send(query, cancellationToken);
+        if (resultado.EsExitoso)
+            return Ok(resultado.Valor);
+        
+        return BadRequest(resultado.Error);
+    }
 }


### PR DESCRIPTION

## Description
This PR adds a new method to filter users based on provided lists of interest and skill IDs. The method returns users who have at least one of the specified interests or skills. It properly handles nullable IDs and avoids duplicates.

## Changes
- Added `FiltrarPorInteresesYHabilidadesAsync` method to the user repository.
- The method accepts nullable lists of interest and skill GUIDs and a cancellation token.
- Uses efficient querying with EF Core and returns filtered users.
- Returns an empty list if no matching users are found.

## Commit Messages
- feat(user): add filter method by interests and skills
- feat: filter users by interest and ability IDs
