### PR TITLE
feat(admin/user): implement admin queries and add position field to user entity

### DIFF
--- a/Trivo.Aplicacion/DTOs/Cuentas/Expertos/UsuarioDetallesExpertoDto.cs
+++ b/Trivo.Aplicacion/DTOs/Cuentas/Expertos/UsuarioDetallesExpertoDto.cs
@@ -10,8 +10,9 @@ public sealed record UsuarioDetallesExpertoDto(
     string? Ubicacion,
     string? Biografia,
     string? FotoPerfil,
+    string? Posicion,
     IEnumerable<HabilidadNombreDto> Habilidad,
     IEnumerable<InteresDto> Interes,
     bool? DisponibleParaProyectos,
     bool? Contratado
-) : UsuarioDetallesDto(Nombre, Apellido, Ubicacion, Biografia, FotoPerfil, Habilidad, Interes);
+) : UsuarioDetallesDto(Nombre, Apellido, Ubicacion, Biografia, FotoPerfil, Posicion ,Habilidad, Interes);

--- a/Trivo.Aplicacion/DTOs/Cuentas/Reclutador/UsuarioDetallesReclutadorDto.cs
+++ b/Trivo.Aplicacion/DTOs/Cuentas/Reclutador/UsuarioDetallesReclutadorDto.cs
@@ -10,7 +10,8 @@ public sealed record UsuarioDetallesReclutadorDto(
     string? Ubicacion,
     string? Biografia,
     string? FotoPerfil,
+    string? Posicion,
     IEnumerable<HabilidadNombreDto> Habilidad,
     IEnumerable<InteresDto> Interes,
     string? NombreEmpresa
-) : UsuarioDetallesDto(Nombre, Apellido, Ubicacion, Biografia, FotoPerfil, Habilidad, Interes);
+) : UsuarioDetallesDto(Nombre, Apellido, Ubicacion, Biografia, FotoPerfil, Posicion , Habilidad, Interes);

--- a/Trivo.Aplicacion/DTOs/Cuentas/Usuarios/ConteoUsuariosActivosDto.cs
+++ b/Trivo.Aplicacion/DTOs/Cuentas/Usuarios/ConteoUsuariosActivosDto.cs
@@ -1,0 +1,3 @@
+namespace Trivo.Aplicacion.DTOs.Cuentas.Usuarios;
+
+public sealed record ConteoUsuariosActivosDto(int ConteoUsuariosActivos);

--- a/Trivo.Aplicacion/DTOs/Cuentas/Usuarios/UsuarioDetallesDto.cs
+++ b/Trivo.Aplicacion/DTOs/Cuentas/Usuarios/UsuarioDetallesDto.cs
@@ -10,6 +10,7 @@ public record UsuarioDetallesDto
     string? Ubicacion,
     string? Biografia,
     string? FotoPerfil,
+    string? Posicion,
     IEnumerable<HabilidadNombreDto>? Habilidad,
     IEnumerable<InteresDto>? Interes
 );

--- a/Trivo.Aplicacion/DTOs/Cuentas/Usuarios/UsuarioDto.cs
+++ b/Trivo.Aplicacion/DTOs/Cuentas/Usuarios/UsuarioDto.cs
@@ -11,6 +11,7 @@ public sealed record UsuarioDto
     string? Email,
     string? NombreUsuario,
     string? Ubicacion,
+    string? Posicion,
     string? FotoPerfil,
     string? EstadoUsuario,
     DateTime? FechaRegistro

--- a/Trivo.Aplicacion/DTOs/Cuentas/Usuarios/UsuarioReconmendacionDto.cs
+++ b/Trivo.Aplicacion/DTOs/Cuentas/Usuarios/UsuarioReconmendacionDto.cs
@@ -9,6 +9,7 @@ public sealed record UsuarioReconmendacionDto
     string? Nombre,
     string? Apellido,
     string? Biografia,
+    string? Posicion,
     List<InteresConIdDto> Intereses,
     List<HabilidadConIdDto> Habilidades,
     string? FotoPerfil

--- a/Trivo.Aplicacion/DTOs/Emparejamiento/ConteoEmparejamientoCompletadosDto.cs
+++ b/Trivo.Aplicacion/DTOs/Emparejamiento/ConteoEmparejamientoCompletadosDto.cs
@@ -1,0 +1,3 @@
+namespace Trivo.Aplicacion.DTOs.Emparejamiento;
+
+public record ConteoEmparejamientoCompletadosDto(int EmparejamientosCompletados);

--- a/Trivo.Aplicacion/DTOs/Reportes/ReporteBanDto.cs
+++ b/Trivo.Aplicacion/DTOs/Reportes/ReporteBanDto.cs
@@ -1,0 +1,9 @@
+namespace Trivo.Aplicacion.DTOs.Reportes;
+
+public sealed record ReporteBanDto
+(
+    Guid ReporteId,
+    Guid? ReportadoPor,
+    UsuarioReportado Reportado
+);
+public sealed record UsuarioReportado(Guid? ReportadoId, string? Nombre);

--- a/Trivo.Aplicacion/Interfaces/Repositorio/Cuenta/IRepositorioAdministrador.cs
+++ b/Trivo.Aplicacion/Interfaces/Repositorio/Cuenta/IRepositorioAdministrador.cs
@@ -9,7 +9,7 @@ public interface IRepositorioAdministrador : IRepositorioGenerico<Administrador>
 
     Task DesbanearUsuarioAsync(Guid usuarioId, CancellationToken cancellationToken);
 
-    Task<ResultadoPaginado<Usuario>> ObtenerPaginadoUsuariosBaneadosAsync(
+    Task<ResultadoPaginado<Reporte>> ObtenerPaginadoUltimosBan(
         int numeroPagina,
         int tamanoPagina,
         CancellationToken cancellationToken);

--- a/Trivo.Aplicacion/Interfaces/Repositorio/Cuenta/IRepositorioAdministrador.cs
+++ b/Trivo.Aplicacion/Interfaces/Repositorio/Cuenta/IRepositorioAdministrador.cs
@@ -1,3 +1,4 @@
+using Trivo.Aplicacion.Paginacion;
 using Trivo.Dominio.Modelos;
 
 namespace Trivo.Aplicacion.Interfaces.Repositorio.Cuenta;
@@ -7,8 +8,11 @@ public interface IRepositorioAdministrador : IRepositorioGenerico<Administrador>
     Task BanearUsuarioAsync(Guid usuarioId, CancellationToken cancellationToken);
 
     Task DesbanearUsuarioAsync(Guid usuarioId, CancellationToken cancellationToken);
-    
-    Task<IEnumerable<Usuario>> ObtenerUsuariosBaneadosAsync(CancellationToken cancellationToken);
+
+    Task<ResultadoPaginado<Usuario>> ObtenerPaginadoUsuariosBaneadosAsync(
+        int numeroPagina,
+        int tamanoPagina,
+        CancellationToken cancellationToken);
 
     Task<bool> NombreUsuarioEnUso(string nombreUsuario, Guid usuarioId, CancellationToken cancellationToken);
 
@@ -21,4 +25,19 @@ public interface IRepositorioAdministrador : IRepositorioGenerico<Administrador>
     Task<bool> ExisteNombreUsuarioAsync(string nombreUsuario, CancellationToken cancellationToken);
 
     Task ActualizarContrasenaAsync(Administrador admin, string nuevaContrasena);
+    
+    Task<ResultadoPaginado<Usuario>> ObtenerPaginadoUltimosUsuariosAsync(
+        int numeroPagina,
+        int tamanoPagina,
+        CancellationToken cancellationToken);
+
+
+    Task<ResultadoPaginado<Emparejamiento>> ObtenerPaginadoUltimosEmparejamientosAsync(
+        int numeroPagina,
+        int tamanoPagina,
+        CancellationToken cancellationToken);
+
+    Task<int> ContarEmparejamientosCompletadosAsync(CancellationToken cancellationToken);
+
+    Task<int> ContarUsuariosActivosAsync(CancellationToken cancellationToken);
 }

--- a/Trivo.Aplicacion/Mapper/UsuarioMapper.cs
+++ b/Trivo.Aplicacion/Mapper/UsuarioMapper.cs
@@ -1,6 +1,7 @@
 using Trivo.Aplicacion.DTOs.Cuentas.Usuarios;
 using Trivo.Aplicacion.DTOs.Habilidades;
 using Trivo.Aplicacion.DTOs.Intereses;
+using Trivo.Dominio.Enum;
 
 namespace Trivo.Aplicacion.Mapper;
 
@@ -13,9 +14,31 @@ public static class UsuarioMapper
             Nombre: entidad.Nombre,
             Apellido: entidad.Apellido,
             Biografia: entidad.Biografia,
+            Posicion: entidad.Posicion,
             Intereses: entidad.UsuarioInteres?.Select(i => new InteresConIdDto(i.Interes?.Id ?? Guid.Empty, i.Interes?.Nombre ?? "")).ToList() ?? new List<InteresConIdDto>(),
             Habilidades: entidad.UsuarioHabilidades?.Select(h => new HabilidadConIdDto(h.Habilidad?.HabilidadId ?? Guid.Empty, h.Habilidad?.Nombre ?? "")).ToList() ?? new List<HabilidadConIdDto>(),
             FotoPerfil: entidad.FotoPerfil
         );
     }
+
+    public static UsuarioDto MapUsuarioDto(Dominio.Modelos.Usuario usuario)
+    {
+        return new UsuarioDto
+        (
+            UsuarioId: usuario.Id,
+            Nombre: usuario.Nombre,
+            Apellido: usuario.Apellido,
+            Biografia: usuario.Biografia,
+            Email: usuario.Email,
+            NombreUsuario: usuario.NombreUsuario,
+            Ubicacion: usuario.Ubicacion,
+            Posicion: usuario.Posicion,
+            FotoPerfil: usuario.FotoPerfil,
+            EstadoUsuario: usuario.EstadoUsuario,
+            FechaRegistro: usuario.FechaRegistro
+        );
+    }
+    
+    
+    
 }

--- a/Trivo.Aplicacion/Modulos/Administrador/Querys/ObtenerConteoDeEmparejamientos/ObtenerConteoEmparejamientosCompletadosQuery.cs
+++ b/Trivo.Aplicacion/Modulos/Administrador/Querys/ObtenerConteoDeEmparejamientos/ObtenerConteoEmparejamientosCompletadosQuery.cs
@@ -1,0 +1,6 @@
+using Trivo.Aplicacion.Abstracciones.Mensajes;
+using Trivo.Aplicacion.DTOs.Emparejamiento;
+
+namespace Trivo.Aplicacion.Modulos.Administrador.Querys.ObtenerConteoDeEmparejamientos;
+
+public sealed record ObtenerConteoEmparejamientosCompletadosQuery() : IQuery<ConteoEmparejamientoCompletadosDto>;

--- a/Trivo.Aplicacion/Modulos/Administrador/Querys/ObtenerConteoDeEmparejamientos/ObtenerConteoEmparejamientosCompletadosQueryHandler.cs
+++ b/Trivo.Aplicacion/Modulos/Administrador/Querys/ObtenerConteoDeEmparejamientos/ObtenerConteoEmparejamientosCompletadosQueryHandler.cs
@@ -1,0 +1,30 @@
+using Microsoft.Extensions.Logging;
+using Serilog;
+using Trivo.Aplicacion.Abstracciones.Mensajes;
+using Trivo.Aplicacion.DTOs.Emparejamiento;
+using Trivo.Aplicacion.Interfaces.Repositorio.Cuenta;
+using Trivo.Aplicacion.Utilidades;
+
+namespace Trivo.Aplicacion.Modulos.Administrador.Querys.ObtenerConteoDeEmparejamientos;
+internal sealed class ObtenerConteoEmparejamientosCompletadosQueryHandler(
+    ILogger<ObtenerConteoEmparejamientosCompletadosQueryHandler> logger,
+    IRepositorioAdministrador repositorioAdministrador
+    ) : IQueryHandler<ObtenerConteoEmparejamientosCompletadosQuery, ConteoEmparejamientoCompletadosDto>
+{
+    public async Task<ResultadoT<ConteoEmparejamientoCompletadosDto>> Handle(ObtenerConteoEmparejamientosCompletadosQuery request, CancellationToken cancellationToken)
+    {
+        var conteoEmparejamiento =
+            await repositorioAdministrador.ContarEmparejamientosCompletadosAsync(cancellationToken);
+
+        if (conteoEmparejamiento == 0)
+        {
+            logger.LogWarning("No se encontraron emparejamientos completados.");
+            
+            return ResultadoT<ConteoEmparejamientoCompletadosDto>.Fallo(Error.NoEncontrado("404",""));
+        }
+        
+        logger.LogInformation("Se encontraron {ConteoEmparejamiento} emparejamientos completados.", conteoEmparejamiento);
+        
+        return ResultadoT<ConteoEmparejamientoCompletadosDto>.Exito(new ConteoEmparejamientoCompletadosDto(conteoEmparejamiento));
+    }
+}

--- a/Trivo.Aplicacion/Modulos/Administrador/Querys/ObtenerConteoDeUsuariosActivos/ObtenerConteoUsuariosActivosQuery.cs
+++ b/Trivo.Aplicacion/Modulos/Administrador/Querys/ObtenerConteoDeUsuariosActivos/ObtenerConteoUsuariosActivosQuery.cs
@@ -1,0 +1,6 @@
+using Trivo.Aplicacion.Abstracciones.Mensajes;
+using Trivo.Aplicacion.DTOs.Cuentas.Usuarios;
+
+namespace Trivo.Aplicacion.Modulos.Administrador.Querys.ObtenerConteoDeUsuariosActivos;
+
+public sealed record ObtenerConteoUsuariosActivosQuery() : IQuery<ConteoUsuariosActivosDto>;

--- a/Trivo.Aplicacion/Modulos/Administrador/Querys/ObtenerConteoDeUsuariosActivos/ObtenerConteoUsuariosActivosQueryHandler.cs
+++ b/Trivo.Aplicacion/Modulos/Administrador/Querys/ObtenerConteoDeUsuariosActivos/ObtenerConteoUsuariosActivosQueryHandler.cs
@@ -1,0 +1,32 @@
+using Microsoft.Extensions.Logging;
+using Trivo.Aplicacion.Abstracciones.Mensajes;
+using Trivo.Aplicacion.DTOs.Cuentas.Usuarios;
+using Trivo.Aplicacion.Interfaces.Repositorio.Cuenta;
+using Trivo.Aplicacion.Utilidades;
+
+namespace Trivo.Aplicacion.Modulos.Administrador.Querys.ObtenerConteoDeUsuariosActivos;
+
+internal sealed class ObtenerConteoUsuariosActivosQueryHandler(
+    ILogger<ObtenerConteoUsuariosActivosQueryHandler> logger,
+    IRepositorioAdministrador repositorioAdministrador
+    ) : IQueryHandler<ObtenerConteoUsuariosActivosQuery, ConteoUsuariosActivosDto>
+{
+    public async Task<ResultadoT<ConteoUsuariosActivosDto>> Handle(ObtenerConteoUsuariosActivosQuery request, CancellationToken cancellationToken)
+    {
+        var conteoUsuariosActivos =
+            await repositorioAdministrador.ContarUsuariosActivosAsync(cancellationToken);
+
+        if (conteoUsuariosActivos == 0)
+        {
+            logger.LogInformation("No se encontraron usuarios activos en la base de datos.");
+        
+            return ResultadoT<ConteoUsuariosActivosDto>.Fallo(
+                Error.NoEncontrado("404", "No se encontraron usuarios activos."));
+        }
+    
+        logger.LogInformation("Se encontraron {ConteoUsuariosActivos} usuarios activos.", conteoUsuariosActivos);
+    
+        return ResultadoT<ConteoUsuariosActivosDto>.Exito(new ConteoUsuariosActivosDto(conteoUsuariosActivos));
+    }
+
+}

--- a/Trivo.Aplicacion/Modulos/Administrador/Querys/ObtenerUltimosUsuarios/ObtenerUltimosUsuariosPaginadosQuery.cs
+++ b/Trivo.Aplicacion/Modulos/Administrador/Querys/ObtenerUltimosUsuarios/ObtenerUltimosUsuariosPaginadosQuery.cs
@@ -1,0 +1,11 @@
+using Trivo.Aplicacion.Abstracciones.Mensajes;
+using Trivo.Aplicacion.DTOs.Cuentas.Usuarios;
+using Trivo.Aplicacion.Paginacion;
+
+namespace Trivo.Aplicacion.Modulos.Administrador.Querys.ObtenerUltimosUsuarios;
+
+public sealed record ObtenerUltimosUsuariosPaginadosQuery
+(
+    int NumeroPagina,
+    int TamanoPagina
+) : IQuery<ResultadoPaginado<UsuarioDto>>;

--- a/Trivo.Aplicacion/Modulos/Administrador/Querys/ObtenerUltimosUsuarios/ObtenerUltimosUsuariosPaginadosQueryHandler.cs
+++ b/Trivo.Aplicacion/Modulos/Administrador/Querys/ObtenerUltimosUsuarios/ObtenerUltimosUsuariosPaginadosQueryHandler.cs
@@ -1,0 +1,67 @@
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Logging;
+using Trivo.Aplicacion.Abstracciones.Mensajes;
+using Trivo.Aplicacion.DTOs.Cuentas.Usuarios;
+using Trivo.Aplicacion.Interfaces.Repositorio.Cuenta;
+using Trivo.Aplicacion.Mapper;
+using Trivo.Aplicacion.Paginacion;
+using Trivo.Aplicacion.Utilidades;
+
+namespace Trivo.Aplicacion.Modulos.Administrador.Querys.ObtenerUltimosUsuarios;
+
+internal sealed class ObtenerUltimosUsuariosPaginadosQueryHandler(
+    ILogger<ObtenerUltimosUsuariosPaginadosQueryHandler> logger,
+    IRepositorioAdministrador repositorioAdministrador,
+    IDistributedCache cache
+    ) : IQueryHandler<ObtenerUltimosUsuariosPaginadosQuery, ResultadoPaginado<UsuarioDto>>
+{
+    public async Task<ResultadoT<ResultadoPaginado<UsuarioDto>>> Handle(ObtenerUltimosUsuariosPaginadosQuery request, CancellationToken cancellationToken)
+    {
+        if (request is null)
+        {
+            logger.LogWarning("La solicitud para obtener los últimos usuarios registrados fue nula.");
+        
+            return ResultadoT<ResultadoPaginado<UsuarioDto>>.Fallo(
+                Error.Fallo("400", "La solicitud no puede ser nula."));
+        }
+
+        if (request.NumeroPagina <= 0 || request.TamanoPagina <= 0)
+        {
+            logger.LogWarning("Parámetros inválidos para la paginación: Número de página ({NumeroPagina}) o Tamaño de página ({TamanoPagina}) no son válidos.", 
+                request.NumeroPagina, request.TamanoPagina);
+        
+            return ResultadoT<ResultadoPaginado<UsuarioDto>>.Fallo(
+                Error.Fallo("400", "Número de página y tamaño de página deben ser mayores a cero."));
+        }
+
+        var resultadoPaginadoDto = await cache.ObtenerOCrearAsync(
+            $"obtener-ultimos-usuarios-registrados-{request.NumeroPagina}-{request.TamanoPagina}",
+            async () =>
+            {
+                var resultado = await repositorioAdministrador.ObtenerPaginadoUltimosUsuariosAsync(request.NumeroPagina,
+                    request.TamanoPagina,
+                    cancellationToken);
+                
+                var resultadoDto = resultado.Elementos!
+                    .Select(UsuarioMapper.MapUsuarioDto)
+                    .ToList();
+                
+                var resultadoPaginado = new ResultadoPaginado<UsuarioDto>(
+                    elementos: resultadoDto,
+                    totalElementos: resultado.TotalElementos,
+                    paginaActual: request.NumeroPagina,
+                    tamanioPagina: request.TamanoPagina
+                );
+                
+                return resultadoPaginado;
+            },
+            cancellationToken: cancellationToken
+        );
+        
+        logger.LogInformation("Se obtuvieron {Cantidad} usuarios registrados recientemente (Página: {NumeroPagina}, Tamaño: {TamanoPagina}).",
+            resultadoPaginadoDto.Elementos!.Count(), request.NumeroPagina, request.TamanoPagina);
+
+        
+        return ResultadoT<ResultadoPaginado<UsuarioDto>>.Exito(resultadoPaginadoDto);
+    }
+}

--- a/Trivo.Aplicacion/Modulos/Administrador/Querys/ObtenerUsuariosBaneados/ObtenerUsuariosBaneadosConPaginacionQuery.cs
+++ b/Trivo.Aplicacion/Modulos/Administrador/Querys/ObtenerUsuariosBaneados/ObtenerUsuariosBaneadosConPaginacionQuery.cs
@@ -1,0 +1,7 @@
+namespace Trivo.Aplicacion.Modulos.Administrador.Querys.ObtenerUsuariosBaneados;
+
+public sealed record ObtenerUsuariosBaneadosConPaginacionQuery
+(
+    int NumeroPagina,
+    int TamanoPagina
+);

--- a/Trivo.Aplicacion/Modulos/Administrador/Querys/ObtenerUsuariosBaneados/ObtenerUsuariosBaneadosConPaginacionQuery.cs
+++ b/Trivo.Aplicacion/Modulos/Administrador/Querys/ObtenerUsuariosBaneados/ObtenerUsuariosBaneadosConPaginacionQuery.cs
@@ -1,7 +1,11 @@
+using Trivo.Aplicacion.Abstracciones.Mensajes;
+using Trivo.Aplicacion.DTOs.Reportes;
+using Trivo.Aplicacion.Paginacion;
+
 namespace Trivo.Aplicacion.Modulos.Administrador.Querys.ObtenerUsuariosBaneados;
 
 public sealed record ObtenerUsuariosBaneadosConPaginacionQuery
 (
     int NumeroPagina,
     int TamanoPagina
-);
+) : IQuery<ResultadoPaginado<ReporteBanDto>>;

--- a/Trivo.Aplicacion/Modulos/Administrador/Querys/ObtenerUsuariosBaneados/ObtenerUsuariosBaneadosConPaginacionQueryHandler.cs
+++ b/Trivo.Aplicacion/Modulos/Administrador/Querys/ObtenerUsuariosBaneados/ObtenerUsuariosBaneadosConPaginacionQueryHandler.cs
@@ -1,6 +1,51 @@
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Logging;
+using Serilog;
+using Trivo.Aplicacion.Abstracciones.Mensajes;
+using Trivo.Aplicacion.DTOs.Reportes;
+using Trivo.Aplicacion.Interfaces.Repositorio.Cuenta;
+using Trivo.Aplicacion.Paginacion;
+using Trivo.Aplicacion.Utilidades;
+using Trivo.Dominio.Modelos;
+
 namespace Trivo.Aplicacion.Modulos.Administrador.Querys.ObtenerUsuariosBaneados;
 
-internal sealed class ObtenerUsuariosBaneadosConPaginacionQueryHandler
+internal sealed class ObtenerUsuariosBaneadosConPaginacionQueryHandler(
+    ILogger<ObtenerUsuariosBaneadosConPaginacionQueryHandler> logger,
+    IRepositorioAdministrador repositorioAdministrador,
+    IDistributedCache cache
+    ) : IQueryHandler<ObtenerUsuariosBaneadosConPaginacionQuery, ResultadoPaginado<ReporteBanDto>>
 {
-    
+    public async Task<ResultadoT<ResultadoPaginado<ReporteBanDto>>> Handle(ObtenerUsuariosBaneadosConPaginacionQuery request, CancellationToken cancellationToken)
+    {
+        if (request.NumeroPagina <= 0 || request.TamanoPagina <= 0)
+        {
+            logger.LogWarning("");
+            
+            return ResultadoT<ResultadoPaginado<ReporteBanDto>>.Fallo(Error.Fallo("400",""));
+        }
+
+        // var resultadoPaginado = await cache.ObtenerOCrearAsync(
+        //     $"obtener-ultimos-usuarios-baneados-{request.NumeroPagina}-{request.TamanoPagina}",
+        //     async () =>
+        //     {
+        //         var pagina = await repositorioAdministrador.ObtenerPaginadoUltimosBan(request.NumeroPagina,
+        //             request.TamanoPagina, cancellationToken);
+        //
+        //         var resultadoPaginaDto = pagina.Elementos!.Select(reporte => new ReporteBanDto
+        //         (
+        //             ReporteId: reporte.ReporteId ?? Guid.Empty,
+        //             ReportadoPor: reporte.ReportadoPor,
+        //             Reportado: new UsuarioReportado
+        //             (
+        //                 ReportadoId: reporte.,
+        //                 Nombre: reporte.Reportado.Nombre
+        //             )
+        //         )).ToList();
+        //
+        //     }
+        // );
+
+        return null;
+    }
 }

--- a/Trivo.Aplicacion/Modulos/Administrador/Querys/ObtenerUsuariosBaneados/ObtenerUsuariosBaneadosConPaginacionQueryHandler.cs
+++ b/Trivo.Aplicacion/Modulos/Administrador/Querys/ObtenerUsuariosBaneados/ObtenerUsuariosBaneadosConPaginacionQueryHandler.cs
@@ -1,0 +1,6 @@
+namespace Trivo.Aplicacion.Modulos.Administrador.Querys.ObtenerUsuariosBaneados;
+
+internal sealed class ObtenerUsuariosBaneadosConPaginacionQueryHandler
+{
+    
+}

--- a/Trivo.Aplicacion/Modulos/Usuario/Commands/Crear/CrearUsuarioCommand.cs
+++ b/Trivo.Aplicacion/Modulos/Usuario/Commands/Crear/CrearUsuarioCommand.cs
@@ -14,6 +14,7 @@ public sealed class CrearUsuarioCommand : ICommand<UsuarioDto>
     public string? NombreUsuario { get; set; }
     public string? Ubicacion { get; set; }
     
+    public string? Posicion { get; set; }
     public List<Guid>? Intereses { get; set; }
     public IFormFile? Foto { get; set; }
 }

--- a/Trivo.Aplicacion/Modulos/Usuario/Commands/Crear/CrearUsuarioCommandHandler.cs
+++ b/Trivo.Aplicacion/Modulos/Usuario/Commands/Crear/CrearUsuarioCommandHandler.cs
@@ -112,6 +112,7 @@ internal sealed class CrearUsuarioCommandHandler(
                 Email: usuario.Email,
                 NombreUsuario: usuario.NombreUsuario,
                 Ubicacion: usuario.Ubicacion,
+                Posicion: usuario.Posicion,
                 FotoPerfil: usuario.FotoPerfil,
                 EstadoUsuario: usuario.EstadoUsuario,
                 FechaRegistro: usuario.FechaRegistro

--- a/Trivo.Aplicacion/Modulos/Usuario/Commands/Crear/CrearUsuarioCommandHandler.cs
+++ b/Trivo.Aplicacion/Modulos/Usuario/Commands/Crear/CrearUsuarioCommandHandler.cs
@@ -65,7 +65,8 @@ internal sealed class CrearUsuarioCommandHandler(
                 NombreUsuario = request.NombreUsuario,
                 Ubicacion = request.Ubicacion,
                 FotoPerfil = imageUrl,
-                EstadoUsuario = nameof(EstadoUsuario.Activo)
+                EstadoUsuario = nameof(EstadoUsuario.Activo),
+                Posicion = request.Posicion
             };
 
             await repositorioUsuario.CrearAsync(usuario, cancellationToken);

--- a/Trivo.Aplicacion/Modulos/Usuario/Commands/Crear/CrearUsuarioValidacion.cs
+++ b/Trivo.Aplicacion/Modulos/Usuario/Commands/Crear/CrearUsuarioValidacion.cs
@@ -16,6 +16,10 @@ public class CrearUsuarioValidacion : AbstractValidator<CrearUsuarioCommand>
             .NotEmpty().WithMessage("El apellido es obligatorio.")
             .MaximumLength(30).WithMessage("El apellido no debe exceder los 30 caracteres.");
 
+        RuleFor(x => x.Posicion)
+            .NotEmpty()
+            .WithMessage("El campo de posicion es obligatorio");
+        
         RuleFor(x => x.Biografia)
             .NotEmpty().WithMessage("La biografía es obligatoria");
 

--- a/Trivo.Aplicacion/Modulos/Usuario/Querys/ObtenerDetalles/ObtenerDetallesUsuarioQueryHandler.cs
+++ b/Trivo.Aplicacion/Modulos/Usuario/Querys/ObtenerDetalles/ObtenerDetallesUsuarioQueryHandler.cs
@@ -57,6 +57,7 @@ internal sealed class ObtenerDetallesUsuarioQueryHandler(
                         Ubicacion: usuarioDetalles.Ubicacion,
                         Biografia: usuarioDetalles.Biografia,
                         FotoPerfil: usuarioDetalles.FotoPerfil,
+                        Posicion: usuarioDetalles.Posicion,
                         Habilidad: HabilidadesMapper.MapHabilidades(usuarioDetalles.UsuarioHabilidades),
                         Interes: MapperInteres.MapIntereses(usuarioDetalles.UsuarioInteres),
                         DisponibleParaProyectos: experto?.DisponibleParaProyectos,
@@ -86,6 +87,7 @@ internal sealed class ObtenerDetallesUsuarioQueryHandler(
                         Ubicacion: usuarioDetalles.Ubicacion,
                         Biografia: usuarioDetalles.Biografia,
                         FotoPerfil: usuarioDetalles.FotoPerfil,
+                        Posicion: usuarioDetalles.Posicion,
                         Habilidad: HabilidadesMapper.MapHabilidades(usuarioDetalles.UsuarioHabilidades),
                         Interes: MapperInteres.MapIntereses(usuarioDetalles.UsuarioInteres),
                         NombreEmpresa: reclutador?.NombreEmpresa
@@ -107,6 +109,7 @@ internal sealed class ObtenerDetallesUsuarioQueryHandler(
             Ubicacion: usuarioDetalles.Ubicacion,
             Biografia: usuarioDetalles.Biografia,
             FotoPerfil: usuarioDetalles.FotoPerfil,
+            Posicion: usuarioDetalles.Posicion,
             Habilidad: HabilidadesMapper.MapHabilidades(usuarioDetalles.UsuarioHabilidades),
             Interes: MapperInteres.MapIntereses(usuarioDetalles.UsuarioInteres)
         );

--- a/Trivo.Dominio/Modelos/Usuario.cs
+++ b/Trivo.Dominio/Modelos/Usuario.cs
@@ -26,6 +26,8 @@ public sealed class Usuario : EntidadBase
 
     public string? EstadoUsuario { get; set; }
     
+    public string? Posicion { get; set; }
+    
     // Relaciones
     public ICollection<Codigo>? Codigos { get; set; }
     

--- a/Trivo.Infraestructura.Compartido/Servicios/AutenticacionServicio.cs
+++ b/Trivo.Infraestructura.Compartido/Servicios/AutenticacionServicio.cs
@@ -76,7 +76,7 @@ public class AutenticacionServicio(
             new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
             new Claim(JwtRegisteredClaimNames.Email, admin.Email!),
             new Claim("nombreUsuario", admin.NombreUsuario!),
-            new Claim("rol", Roles.Administrador.ToString()),
+            new Claim("roles", Roles.Administrador.ToString()),
             new Claim("tipo", "access")
         };
 

--- a/Trivo.Infraestructura.Persistencia/Contexto/TrivoContexto.cs
+++ b/Trivo.Infraestructura.Persistencia/Contexto/TrivoContexto.cs
@@ -416,6 +416,10 @@ public class TrivoContexto : DbContext
                     .IsRequired()
                     .HasMaxLength(255);
 
+                entity.Property(u => u.Posicion)
+                    .IsRequired()
+                    .HasMaxLength(50);
+                
                 entity.Property(u => u.NombreUsuario)
                     .IsRequired()              
                     .HasMaxLength(50);
@@ -449,7 +453,6 @@ public class TrivoContexto : DbContext
                     .IsRequired()
                     .HasColumnType("varchar(50)");
             });
-            
 
         #endregion
         

--- a/Trivo.Infraestructura.Persistencia/Migrations/20250725004045_AgregarPosicionAtributo.Designer.cs
+++ b/Trivo.Infraestructura.Persistencia/Migrations/20250725004045_AgregarPosicionAtributo.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Trivo.Infraestructura.Persistencia.Contexto;
@@ -11,9 +12,11 @@ using Trivo.Infraestructura.Persistencia.Contexto;
 namespace Trivo.Infraestructura.Persistencia.Migrations
 {
     [DbContext(typeof(TrivoContexto))]
-    partial class TrivoContextoModelSnapshot : ModelSnapshot
+    [Migration("20250725004045_AgregarPosicionAtributo")]
+    partial class AgregarPosicionAtributo
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Trivo.Infraestructura.Persistencia/Migrations/20250725004045_AgregarPosicionAtributo.cs
+++ b/Trivo.Infraestructura.Persistencia/Migrations/20250725004045_AgregarPosicionAtributo.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Trivo.Infraestructura.Persistencia.Migrations
+{
+    /// <inheritdoc />
+    public partial class AgregarPosicionAtributo : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Posicion",
+                table: "Usuario",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: false,
+                defaultValue: "");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Posicion",
+                table: "Usuario");
+        }
+    }
+}

--- a/Trivo.Infraestructura.Persistencia/Repositorio/Cuenta/RepositorioAdministrador.cs
+++ b/Trivo.Infraestructura.Persistencia/Repositorio/Cuenta/RepositorioAdministrador.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Trivo.Aplicacion.Interfaces.Repositorio.Cuenta;
+using Trivo.Aplicacion.Paginacion;
 using Trivo.Dominio.Enum;
 using Trivo.Dominio.Modelos;
 using Trivo.Infraestructura.Persistencia.Contexto;
@@ -66,4 +67,79 @@ public class RepositorioAdministrador(TrivoContexto trivoContexto) :
         _trivoContexto.Set<Administrador>().Update(admin);
         await _trivoContexto.SaveChangesAsync();
     }
+   public async Task<ResultadoPaginado<Usuario>> ObtenerPaginadoUsuariosBaneadosAsync(
+       int numeroPagina,
+       int tamanoPagina,
+       CancellationToken cancellationToken)
+   {
+       var consulta = _trivoContexto.Set<Usuario>()
+           .AsNoTracking()
+           .Where(usuario => usuario.EstadoUsuario == nameof(EstadoUsuario.Baneado))
+           .OrderByDescending(x => x.FechaRegistro);
+       
+       var total = await consulta.CountAsync(cancellationToken);
+       
+       var usuariosBaneados = await consulta
+           .Skip((numeroPagina - 1) * tamanoPagina)
+           .Take(tamanoPagina)
+           .ToListAsync(cancellationToken);
+       
+       return new ResultadoPaginado<Usuario>(usuariosBaneados, numeroPagina, tamanoPagina, total);
+   }
+   
+   public async Task<ResultadoPaginado<Usuario>> ObtenerPaginadoUltimosUsuariosAsync(
+       int numeroPagina,
+       int tamanoPagina,
+       CancellationToken cancellationToken)
+   {
+       var consulta = _trivoContexto.Set<Usuario>()
+           .AsNoTracking()
+           .OrderByDescending(x => x.FechaRegistro);
+
+       var total = await consulta.CountAsync(cancellationToken);
+
+       var usuarios = await consulta
+           .Skip((numeroPagina - 1) * tamanoPagina)
+           .Take(tamanoPagina)
+           .ToListAsync(cancellationToken);
+
+       return new ResultadoPaginado<Usuario>(usuarios, total, numeroPagina, tamanoPagina);
+   }
+
+   public async Task<ResultadoPaginado<Emparejamiento>> ObtenerPaginadoUltimosEmparejamientosAsync(
+       int numeroPagina,
+       int tamanoPagina,
+       CancellationToken cancellationToken)
+   {
+       var consulta = _trivoContexto.Set<Emparejamiento>()
+           .AsNoTracking()
+           .OrderByDescending(x => x.FechaRegistro);
+       
+       var total = await consulta.CountAsync(cancellationToken);
+       
+       var emparejamientos = await consulta
+           .Skip((numeroPagina - 1) * tamanoPagina)
+           .Take(tamanoPagina)
+           .ToListAsync(cancellationToken);
+       
+       return new ResultadoPaginado<Emparejamiento>(emparejamientos, numeroPagina, tamanoPagina, total);
+   }
+
+   public Task<int> ContarEmparejamientosCompletadosAsync(CancellationToken cancellationToken)
+   {
+       return Task.FromResult(_trivoContexto
+           .Set<Emparejamiento>()
+           .AsNoTracking()
+           .Count(x => x.EmparejamientoEstado == EmparejamientoEstado.Completado.ToString()));
+   }
+   
+   public async Task<int> ContarUsuariosActivosAsync(
+       CancellationToken cancellationToken)
+   {
+       return await _trivoContexto.Set<Usuario>()
+           .AsNoTracking()
+           .Where(x => x.EstadoUsuario == nameof(EstadoUsuario.Activo))
+           .CountAsync(cancellationToken);
+   }
+   
 }

--- a/Trivo.Infraestructura.Persistencia/Repositorio/Cuenta/RepositorioAdministrador.cs
+++ b/Trivo.Infraestructura.Persistencia/Repositorio/Cuenta/RepositorioAdministrador.cs
@@ -69,6 +69,7 @@ public class RepositorioAdministrador(TrivoContexto trivoContexto) :
            .Where(x => x.EstadoReporte == EstadoReporte.Resuelto.ToString())
            .Include(x => x.Usuario)
            .Where(x => x.Usuario!.EstadoUsuario == EstadoUsuario.Baneado.ToString())
+           .Include(x => x.Mensaje)
            .AsSplitQuery();
        
        var total = await consulta.CountAsync(cancellationToken);

--- a/Trivo.Infraestructura.Persistencia/Repositorio/Cuenta/RepositorioUsuario.cs
+++ b/Trivo.Infraestructura.Persistencia/Repositorio/Cuenta/RepositorioUsuario.cs
@@ -81,6 +81,7 @@ public class RepositorioUsuario(TrivoContexto trivoContexto) :
                 Ubicacion = u.Ubicacion,
                 Biografia = u.Biografia,
                 FotoPerfil = u.FotoPerfil,
+                Posicion = u.Posicion,
 
                 UsuarioHabilidades = u.UsuarioHabilidades!
                     .Select(uh => new UsuarioHabilidad

--- a/Trivo.Presentacion.API/Controllers/V1/AdministradorControlador.cs
+++ b/Trivo.Presentacion.API/Controllers/V1/AdministradorControlador.cs
@@ -1,8 +1,12 @@
 using Asp.Versioning;
 using MediatR;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Trivo.Aplicacion.Modulos.Administrador.Commands.CrearAdministrador;
 using Trivo.Aplicacion.Modulos.Administrador.Commands.InicioSesion;
+using Trivo.Aplicacion.Modulos.Administrador.Querys.ObtenerConteoDeEmparejamientos;
+using Trivo.Aplicacion.Modulos.Administrador.Querys.ObtenerConteoDeUsuariosActivos;
+using Trivo.Aplicacion.Modulos.Administrador.Querys.ObtenerUltimosUsuarios;
 
 namespace Trivo.Presentacion.API.Controllers.V1;
 
@@ -31,4 +35,45 @@ public class AdministradorControlador(IMediator mediator) : ControllerBase
       
       return Ok(resultado.Valor);
    }
+
+   [HttpGet("count/match-complete")]
+   [Authorize(Roles = "Administrador")]
+   public async Task<IActionResult> ObtenerCantidadDeEmperajamientoCompletadosAsync(CancellationToken cancellationToken)
+   {
+      ObtenerConteoEmparejamientosCompletadosQuery query = new();
+      var resultado = await mediator.Send(query, cancellationToken);
+      if (!resultado.EsExitoso)
+         return BadRequest(resultado.Error);
+      
+      return Ok(resultado.Valor);
+   }
+
+   [HttpGet("count/user-active")]
+   [Authorize(Roles = "Administrador")]
+   public async Task<IActionResult> ObtenerCantidadDeUsuariosActivosAsync(CancellationToken cancellationToken)
+   {
+      ObtenerConteoUsuariosActivosQuery query = new();
+      var resultado = await mediator.Send(query, cancellationToken);
+      if (!resultado.EsExitoso)
+         return BadRequest(resultado.Error);
+      
+      return Ok(resultado.Valor);
+   }
+
+   [HttpGet("last-user")]
+   [Authorize(Roles = "Administrador")]
+   public async Task<IActionResult> ObtenerUltimoUsuarioRegistradoAsync(
+      [FromQuery] int numeroPagina,
+      [FromQuery] int tamanoPagina,
+      CancellationToken cancellationToken)
+   {
+      ObtenerUltimosUsuariosPaginadosQuery query = new(numeroPagina, tamanoPagina);
+      var resultado = await mediator.Send(query, cancellationToken);
+      if (!resultado.EsExitoso)
+         return BadRequest(resultado.Error);
+      
+      return Ok(resultado.Valor);
+   }
+   
+   
 }


### PR DESCRIPTION

## Description

This PR introduces several improvements related to user and admin features. It includes the addition of the `position` field to the `User` entity, support for new queries and endpoints for administrators, and the implementation of basic reporting, matching, and messaging functionalities.

## Main Changes

### User
- Added the `Position` property to the `User` entity.
- Updated `UserDetailsDto` and `ExpertDto` to include the `position` field.
- Modified the Entity Framework projection to return the `position` field in detailed queries.

### Queries and Methods
- Added methods to fetch banned users.
- Implemented admin-specific queries and endpoint logic.

### Migrations
- Generated and applied new migrations to include the `position` field in the database.

### Messaging and Reports
- Introduced the `Message` entity as part of a join relationship.
- Created DTOs for both `Report` and `Match` features.

### Security
- Added role-based claims for the `admin` role to support authorization logic.
